### PR TITLE
🐛 adds transform to ProgressSection so z-index applies locally

### DIFF
--- a/uikit/Progress/index.js
+++ b/uikit/Progress/index.js
@@ -41,6 +41,9 @@ const ProgressSection = styled('div')`
   display: flex;
   align-items: flex-end;
 
+  /* this ensures stacking context is local for z-index */
+  transform: scale(1);
+
   /* first and last rounded corners */
   > div:first-of-type:not(:last-of-type) .progress-marker {
     border-radius: 10px 0 0 10px;


### PR DESCRIPTION
**Description of changes**

this prevents the z-index from pushing the `::before` and `::after` to top of page