### PR TITLE
Persist state between page navigations

### DIFF
--- a/components/pages/submission-system/layout.js
+++ b/components/pages/submission-system/layout.js
@@ -19,6 +19,7 @@ import SideMenu from './SideMenu';
 import Footer from 'uikit/Footer';
 import usePersistentState from 'global/hooks/usePersistentContext';
 import debounce from 'lodash/debounce';
+import hasIn from 'lodash/hasIn';
 
 const SubmissionLayout = ({
   sideMenu = <SideMenu />,
@@ -34,18 +35,21 @@ const SubmissionLayout = ({
   subtitle?: string,
 }) => {
   const [sidemenuScrollTop, setSidemenuScrollTop] = usePersistentState('sidemenuScrollTop', 0);
-  const debouncedSet = setter => debounce(setter, 50);
+  const debouncedSet = setter => debounce(setter, 100);
   const panelRef = React.useRef(null);
 
   const handleSidemenuScroll = e => {
     debouncedSet(setSidemenuScrollTop)(e.target.scrollTop);
   };
 
-  React.useLayoutEffect(() => {
-    if (panelRef.current) {
-      panelRef.current.scrollTop = sidemenuScrollTop;
-    }
-  }, []);
+  // Only run on client side, don't run on server side
+  if (hasIn(process, 'browser')) {
+    React.useLayoutEffect(() => {
+      if (panelRef.current) {
+        panelRef.current.scrollTop = sidemenuScrollTop;
+      }
+    }, []);
+  }
 
   return (
     <PageContainer>

--- a/components/pages/submission-system/layout.js
+++ b/components/pages/submission-system/layout.js
@@ -17,6 +17,8 @@ import Head from '../head';
 import NavBar from 'components/NavBar';
 import SideMenu from './SideMenu';
 import Footer from 'uikit/Footer';
+import usePersistentState from 'global/hooks/usePersistentContext';
+import debounce from 'lodash/debounce';
 
 const SubmissionLayout = ({
   sideMenu = <SideMenu />,
@@ -31,12 +33,30 @@ const SubmissionLayout = ({
   children: React.Node,
   subtitle?: string,
 }) => {
+  const [sidemenuScrollTop, setSidemenuScrollTop] = usePersistentState('sidemenuScrollTop', 0);
+  const debouncedSet = setter => debounce(setter, 50);
+  const panelRef = React.useRef(null);
+
+  const handleSidemenuScroll = e => {
+    debouncedSet(setSidemenuScrollTop)(e.target.scrollTop);
+  };
+
+  React.useLayoutEffect(() => {
+    if (panelRef.current) {
+      panelRef.current.scrollTop = sidemenuScrollTop;
+    }
+  }, []);
+
   return (
     <PageContainer>
       <Head title={subtitle ? `ICGC ARGO - ${subtitle}` : 'ICGC ARGO'} />
       <NavBar />
       <PageBody className={clsx({ noSidebar })}>
-        {!noSidebar && <Panel>{sideMenu}</Panel>}
+        {!noSidebar && (
+          <Panel ref={panelRef} onScroll={handleSidemenuScroll}>
+            {sideMenu}
+          </Panel>
+        )}
         <PageContent>
           {contentHeader && <ContentHeader>{contentHeader}</ContentHeader>}
           <ContentBody>{children}</ContentBody>

--- a/components/pages/submission-system/program-management/ManageProgramTabs.js
+++ b/components/pages/submission-system/program-management/ManageProgramTabs.js
@@ -216,7 +216,7 @@ export default () => {
       {activeTab === TABS.USERS && (
         <Users
           programShortName={programShortName}
-          users={loading ? [] : program.users}
+          users={loading ? [] : program ? program.users : []}
           onUserUpdate={() => refetch()}
         />
       )}

--- a/global/hooks/usePersistentContext.js
+++ b/global/hooks/usePersistentContext.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+// persist state between page navigations
+
+export const PersistentContext = React.createContext({});
+
+export function usePersistentContext() {
+  return React.useContext(PersistentContext);
+}
+
+// Just like React.useState, but the state returned by this function is persistent across page refreshes
+export default function usePersistState(key, defaultValue) {
+  const { getItem, setItem } = usePersistentContext();
+  const [persistState, setPersistState] = React.useState(getItem(key, defaultValue));
+
+  return [
+    persistState,
+    val => {
+      setPersistState(val);
+      setItem(key, val);
+    },
+  ];
+}


### PR DESCRIPTION
- Add persistentContext, which contains an usePersistentState hook
that's pretty similar to React.useState except the state is persistent
across page navigations
- Persistent search string in the sidemenu
- Persistent programs in the sidemenu
- Persistent scrolling position of sidemenu

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- [x] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.