### PR TITLE
Use arial-labelledby to describe svg

### DIFF
--- a/uikit/Icon/index.tsx
+++ b/uikit/Icon/index.tsx
@@ -41,9 +41,9 @@ const Icon: React.ComponentType<
       height={height}
       viewBox={svg.viewBox}
       xmlns="http://www.w3.org/2000/svg"
+      aria-labelledby={title || svg.title}
       {...rest}
     >
-      <title lang="en">{title || svg.title}</title>
       <g>
         {svg.mask ? (
           <mask id="mask" fill="#fff">


### PR DESCRIPTION
> If an element can be described by visible text, it is recommended to reference that text with an aria-labelledby attribute rather than using the <title> element.

https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.