### PR TITLE
Feat/#643 spacing on table

### DIFF
--- a/components/pages/submission-system/program-sample-registration/FileTable/index.tsx
+++ b/components/pages/submission-system/program-sample-registration/FileTable/index.tsx
@@ -165,7 +165,7 @@ const FileTable = (props: {
             id: REQUIRED_FILE_ENTRY_FIELDS.ROW,
             Cell: ({ original }) => original.row, // we don't know what should be here
             Header: '#',
-            width: 60,
+            width: 48,
           },
           {
             id: REQUIRED_FILE_ENTRY_FIELDS.IS_NEW,
@@ -180,8 +180,16 @@ const FileTable = (props: {
                 <StarIcon active={original.isNew} />
               </div>
             ),
-            width: 60,
-            Header: <StarIcon active={false} />,
+            width: 48,
+            Header: (
+              <div
+                css={css`
+                  display: flex;
+                `}
+              >
+                <StarIcon active={false} />
+              </div>
+            ),
           },
           ...Object.entries(filteredFirstRecord).map(([key], i, arr) => ({
             id: key,

--- a/uikit/Table/styledComponent.tsx
+++ b/uikit/Table/styledComponent.tsx
@@ -41,7 +41,6 @@ export const StyledTable = styled<typeof ReactTable, { isSelectTable: boolean }>
     ${({ theme }) => css(theme.typography.data)};
     min-height: 28px;
     line-height: 1.33;
-    padding: 2px 8px;
     font-weight: bold;
     align-items: center;
     background: ${({ theme }) => theme.colors.white};
@@ -79,14 +78,16 @@ export const StyledTable = styled<typeof ReactTable, { isSelectTable: boolean }>
   &.ReactTable .rt-thead.-header {
     box-shadow: none;
     border-bottom: solid 1px ${({ theme }) => theme.colors.grey_2};
-    & .rt-th {
-      padding: 10px 16px;
+
+    & .rt-tr .rt-th {
+      padding: ${({ sortable }) => (sortable ? '2px 6px 2px 8px' : '2px 8px')};
       border-left: none;
       border-right: none;
       text-align: left;
       display: flex;
       justify-content: space-between;
     }
+
     ${({ sortable }) =>
       sortable
         ? css`


### PR DESCRIPTION
**Description of changes**

decrease width of # and isNew (star) columns on register samples tables
decrease right padding on sortable table column header, reducing space between sortable arrows and border

**Type of Change**

- [ ] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [x] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
