### PR TITLE
🐛 only hide overflow when loading

### DIFF
--- a/uikit/Container/index.tsx
+++ b/uikit/Container/index.tsx
@@ -5,7 +5,7 @@ import { css, styled } from '..';
 import useTheme from '../utils/useTheme';
 import DnaLoader from '../DnaLoader';
 
-const ContainerBackground = styled<'div', { loading: boolean }>('div')`
+const ContainerBackground = styled<'div', { loading?: boolean }>('div')`
   border-radius: 8px;
   position: relative;
   box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.1), 0 1px 5px 0 rgba(0, 0, 0, 0.08);

--- a/uikit/Container/index.tsx
+++ b/uikit/Container/index.tsx
@@ -5,12 +5,17 @@ import { css, styled } from '..';
 import useTheme from '../utils/useTheme';
 import DnaLoader from '../DnaLoader';
 
-const ContainerBackground = styled('div')`
+const ContainerBackground = styled<'div', { loading: boolean }>('div')`
   border-radius: 8px;
   position: relative;
-  overflow: hidden;
   box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.1), 0 1px 5px 0 rgba(0, 0, 0, 0.08);
   background-color: ${({ theme }) => theme.colors.white};
+  ${({ loading }) =>
+    loading
+      ? css`
+          overflow: hidden;
+        `
+      : ''}
 `;
 
 const LoadingOverlay = () => {
@@ -42,7 +47,7 @@ const Container: React.ComponentType<
     loading?: boolean;
   } & React.ComponentProps<typeof ContainerBackground>
 > = ({ children, loading = false, ...props }) => (
-  <ContainerBackground {...props}>
+  <ContainerBackground {...props} loading={loading}>
     {children}
     {loading && <LoadingOverlay />}
   </ContainerBackground>


### PR DESCRIPTION
**Description of changes**

only apply `overflow: hidden` on `Container` when loading

**Type of Change**

- [x] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
