### PR TITLE
Fix input inside button which is not supported by an old Firefox version

### DIFF
--- a/components/pages/submission-system/SideMenu.tsx
+++ b/components/pages/submission-system/SideMenu.tsx
@@ -137,9 +137,10 @@ const MultiProgramsSection = ({ programs }: { programs: Array<SideMenuProgram> }
       <MenuItem
         level={1}
         selected
+        contentAs="div"
         content={
           <Input
-            aria-label="programs_search"
+            aria-label="programs search"
             onChange={e => {
               setProgramNameSearch(e.target.value);
             }}

--- a/components/pages/submission-system/program-sample-registration/index.tsx
+++ b/components/pages/submission-system/program-sample-registration/index.tsx
@@ -148,8 +148,8 @@ export default function ProgramIDRegistration() {
     } = clinicalRegistration;
     submissionInfo = { createdAt, creator, fileName };
     stats = {
-      newCount: newDonors.count + newSamples.count + newSpecimens.count,
-      existingCount: alreadyRegistered.count,
+      newCount: alreadyRegistered.count,
+      existingCount: newDonors.count + newSamples.count + newSpecimens.count,
     };
   }
 

--- a/components/pages/submission-system/program-sample-registration/index.tsx
+++ b/components/pages/submission-system/program-sample-registration/index.tsx
@@ -148,8 +148,8 @@ export default function ProgramIDRegistration() {
     } = clinicalRegistration;
     submissionInfo = { createdAt, creator, fileName };
     stats = {
-      newCount: alreadyRegistered.count,
-      existingCount: newDonors.count + newSamples.count + newSpecimens.count,
+      newCount: newDonors.count + newSamples.count + newSpecimens.count,
+      existingCount: alreadyRegistered.count,
     };
   }
 

--- a/uikit/SubMenu/index.tsx
+++ b/uikit/SubMenu/index.tsx
@@ -29,6 +29,7 @@ const MenuItemComponent = React.forwardRef<
     children?: any;
     noChevron?: boolean;
     icon?: React.ReactElement<React.ComponentProps<typeof Icon>>;
+    contentAs?: string;
   } & React.ComponentProps<typeof MenuItemContainer>
 >(
   (
@@ -41,6 +42,7 @@ const MenuItemComponent = React.forwardRef<
       onClick = e => {},
       icon,
       noChevron = false,
+      contentAs = 'button',
       ...otherProps
     },
     ref,
@@ -48,7 +50,6 @@ const MenuItemComponent = React.forwardRef<
     const [localSelectedState, setLocalSelectedState] = React.useState(controlledSelectedState);
     const isSelected =
       typeof controlledSelectedState === 'undefined' ? localSelectedState : controlledSelectedState;
-    const theme = useTheme();
     const contentContainerRef = React.createRef<HTMLButtonElement>();
     return (
       <MenuItemContainer
@@ -66,7 +67,7 @@ const MenuItemComponent = React.forwardRef<
       >
         {content && (
           <div className="MenuItemContent">
-            <ContentContainer ref={contentContainerRef}>
+            <ContentContainer ref={contentContainerRef} as={contentAs}>
               {icon && (
                 <IconContainer>
                   {React.cloneElement(icon, {

--- a/uikit/SubMenu/index.tsx
+++ b/uikit/SubMenu/index.tsx
@@ -29,7 +29,7 @@ const MenuItemComponent = React.forwardRef<
     children?: any;
     noChevron?: boolean;
     icon?: React.ReactElement<React.ComponentProps<typeof Icon>>;
-    contentAs?: string;
+    contentAs?: keyof JSX.IntrinsicElements;
   } & React.ComponentProps<typeof MenuItemContainer>
 >(
   (

--- a/uikit/SubMenu/styledComponents.tsx
+++ b/uikit/SubMenu/styledComponents.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import styled from '@emotion/styled';
 import css from '@emotion/css';
 import defaultTheme from 'uikit/theme/defaultTheme';
+import {
+  CreateStyledComponentExtrinsic,
+  CreateStyledComponentIntrinsic,
+} from '@emotion/styled/types';
 
 type StyleCalculationInput = {
   selected?: boolean;
@@ -97,8 +101,7 @@ export const IconContainer = styled('span')`
   align-items: center;
 `;
 
-export const ContentContainer = styled<'button', { as?: string }>('button')`
-  /* overrides button styles */
+export const ContentContainer = styled('button')<{ as?: string }>`
   border: none;
   width: 100%;
   padding: 0px;

--- a/uikit/SubMenu/styledComponents.tsx
+++ b/uikit/SubMenu/styledComponents.tsx
@@ -101,7 +101,7 @@ export const IconContainer = styled('span')`
   align-items: center;
 `;
 
-export const ContentContainer = styled('button')<{ as?: string }>`
+export const ContentContainer = styled('button')<{ as?: keyof JSX.IntrinsicElements }>`
   border: none;
   width: 100%;
   padding: 0px;

--- a/uikit/SubMenu/styledComponents.tsx
+++ b/uikit/SubMenu/styledComponents.tsx
@@ -97,7 +97,7 @@ export const IconContainer = styled('span')`
   align-items: center;
 `;
 
-export const ContentContainer = styled('button')`
+export const ContentContainer = styled<'button', { as?: string }>('button')`
   /* overrides button styles */
   border: none;
   width: 100%;


### PR DESCRIPTION
**Description of changes**

Firefox version 60 in windows 10 does not support focusing on the input
of an button element

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [x] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.