### PR TITLE
Improvements on Clinical submission page

### DIFF
--- a/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
+++ b/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
@@ -95,7 +95,7 @@ export default ({
   submissionData?: React.ComponentProps<typeof SubmissionInfoArea>;
 }) => {
   const theme = useTheme();
-  const { dataErrors, records, dataUpdates } = file;
+  const { records, stats } = file;
   const fields: ClinicalSubmissionEntityFile['records'][0]['fields'] = records.length
     ? records[0].fields
     : [];
@@ -108,8 +108,9 @@ export default ({
   );
 
   const StatusColumCell = ({ original }: { original: typeof tableData[0] }) => {
-    const hasError = dataErrors.some(error => error.row === original.row);
-    const hasUpdate = dataUpdates.some(update => update.row === original.row);
+    const hasError = stats.errorsFound.some(row => row === original.row);
+    const hasUpdate = stats.updated.some(row => row === original.row);
+    const isNew = stats.new.some(row => row === original.row);
     return (
       <CellContentCenter>
         <StarIcon
@@ -118,6 +119,8 @@ export default ({
               ? FILE_STATE_COLORS.ERROR
               : hasUpdate
               ? FILE_STATE_COLORS.UPDATED
+              : isNew
+              ? FILE_STATE_COLORS.NEW
               : FILE_STATE_COLORS.NONE
           }
         />
@@ -170,7 +173,7 @@ export default ({
       <Table
         getTrProps={(_, { original }: { original: typeof tableData[0] }) => ({
           style: {
-            background: dataErrors.some(err => err.row === original.row)
+            background: stats.errorsFound.some(row => row === original.row)
               ? theme.colors.error_4
               : 'none',
           } as CSSProperties,

--- a/components/pages/submission-system/program-clinical-submission/FilesNavigator/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/FilesNavigator/index.tsx
@@ -73,13 +73,17 @@ export default ({
               >
                 {fileState.displayName}
               </div>
-              {fileState.status !== 'NONE' && fileState.status !== 'ERROR' && (
-                <VerticalTabs.Tag variant={fileState.status}>
-                  {fileState.recordsCount}
-                </VerticalTabs.Tag>
-              )}
-              {fileState.status === 'ERROR' && (
-                <VerticalTabs.Tag variant="ERROR">!</VerticalTabs.Tag>
+              {!!fileState.recordsCount && (
+                <>
+                  {fileState.status !== 'NONE' && fileState.status !== 'ERROR' && (
+                    <VerticalTabs.Tag variant={fileState.status}>
+                      {fileState.recordsCount}
+                    </VerticalTabs.Tag>
+                  )}
+                  {fileState.status === 'ERROR' && (
+                    <VerticalTabs.Tag variant="ERROR">!</VerticalTabs.Tag>
+                  )}
+                </>
               )}
             </VerticalTabs.Item>
           ))}

--- a/components/pages/submission-system/program-clinical-submission/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/index.tsx
@@ -32,7 +32,7 @@ import ErrorNotification from './ErrorNotification';
 import { ModalPortal } from 'components/ApplicationRoot';
 import SignOffValidationModal, { useSignOffValidationModalState } from './SignOffValidationModal';
 
-const gqlClinicalEntityToClinicalSubmissionEntityFile = (
+const gqlClinicalEntityToClinicalSubmissionEntityFile = (isSubmissionValidated: boolean) => (
   gqlFile: GqlClinicalEntity,
 ): ClinicalSubmissionEntityFile => {
   return {
@@ -49,7 +49,7 @@ const gqlClinicalEntityToClinicalSubmissionEntityFile = (
     recordsCount: gqlFile.records.length,
     status: !!gqlFile.dataErrors.length
       ? 'ERROR'
-      : !!gqlFile.dataUpdates.length
+      : !!gqlFile.records && isSubmissionValidated
       ? 'SUCCESS'
       : 'WARNING',
   };
@@ -366,7 +366,10 @@ export default function ProgramClinicalSubmission() {
                 }));
               }}
               fileStates={data.clinicalSubmissions.clinicalEntities.map(
-                gqlClinicalEntityToClinicalSubmissionEntityFile,
+                gqlClinicalEntityToClinicalSubmissionEntityFile(
+                  data.clinicalSubmissions.state === 'INVALID' ||
+                    data.clinicalSubmissions.state === 'VALID',
+                ),
               )}
             />
           )}


### PR DESCRIPTION
- fixes the funky error removal behaviour.
  - uses index as the unique identifier for each error
  - updates apollo cache directly instead of going through a local state (`fileError` is ephemeral so no need to worry about being out-of-sync from server-side)

- Hides the badge for each clinical entity when records count is 0
- Implements the success condition on each entity badge when the submission is validated (see https://github.com/icgc-argo/platform-ui/pull/752/commits/95230bf0bfb14077c170a33244ab04c23aaa54a6)
- Implements the purple star for new records (see https://github.com/icgc-argo/platform-ui/pull/752/commits/74c286c05d5dd8aedc658f7b1b66d0cf8313f8ba)
  - Also updates logic to compare row to stats