### PR TITLE
Register sample stats, use rows instead of cols

### DIFF
--- a/components/pages/submission-system/program-sample-registration/REGISTRATION_FRAGMENT.gql
+++ b/components/pages/submission-system/program-sample-registration/REGISTRATION_FRAGMENT.gql
@@ -23,14 +23,18 @@ fragment Registration on ClinicalRegistrationData {
   }
   newDonors {
     count
+    rows
   }
   newSpecimens {
     count
+    rows
   }
   newSamples {
     count
+    rows
   }
   alreadyRegistered {
     count
+    rows
   }
 }


### PR DESCRIPTION
…al columns

**Description of changes**

Previously the stat counter was taking each individual change as a variable even if on same row eg.
new specimen [row 1] + new sample id [row 1] = 2 new files
changed to take rows into account

added `isNew` property to display this on FileTable 

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [x] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
