### PR TITLE
🐛 fixes how env vars are accessed

### DIFF
--- a/components/ApplicationRoot.tsx
+++ b/components/ApplicationRoot.tsx
@@ -16,7 +16,7 @@ import get from 'lodash/get';
 import { createUploadLink } from 'apollo-upload-client';
 
 import { ClientSideGetInitialPropsContext } from 'global/utils/pages/types';
-import { GATEWAY_API_ROOT } from 'global/config';
+import { getConfig } from 'global/config';
 
 const modalPortalRef = React.createRef<HTMLDivElement>();
 const useMounted = () => {
@@ -116,6 +116,7 @@ export default function ApplicationRoot({
   pageContext: ClientSideGetInitialPropsContext;
   children: React.ReactElement;
 }) {
+  const { GATEWAY_API_ROOT } = getConfig();
   const apolloClient = new ApolloClient({
     // $FlowFixMe apollo-client and apollo-link-http have a type conflict in their typing
     link: createUploadLink({

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -18,8 +18,7 @@ import AppBar, {
 import Button from 'uikit/Button';
 import Icon from 'uikit/Icon';
 import Typography from 'uikit/Typography';
-import getConfig from 'next/config';
-import { EGO_URL } from 'global/config';
+import { getConfig } from 'global/config';
 
 const NavBarLoginButton = () => {
   return (
@@ -58,6 +57,7 @@ const getUserRole = egoJwt => {
 };
 
 export default () => {
+  const { EGO_URL } = getConfig();
   const { token: egoJwt, logOut, data: userModel } = useAuthContext();
   const canAccessSubmission = !!egoJwt && (canReadSomeProgram(egoJwt) || isRdpcMember(egoJwt));
   const { asPath: path } = usePageContext();

--- a/components/pages/login.tsx
+++ b/components/pages/login.tsx
@@ -5,8 +5,7 @@ import Container from 'uikit/Container';
 import Typography from 'uikit/Typography';
 import useTheme from 'uikit/utils/useTheme';
 import DefaultLayout from './DefaultLayout';
-import getConfig from 'next/config';
-import { EGO_URL } from 'global/config';
+import { getConfig } from 'global/config';
 
 const LinkToHome = props => <a style={{ cursor: 'pointer' }} {...props} onClick={() => 'TODO'} />;
 
@@ -14,6 +13,7 @@ const LinkToDataRepo = props => <a {...props} onClick={() => 'TODO'} />;
 
 export default function LoginPage() {
   const theme = useTheme();
+  const { EGO_URL } = getConfig();
   return (
     <DefaultLayout>
       <div

--- a/components/pages/submission-system/common.tsx
+++ b/components/pages/submission-system/common.tsx
@@ -8,7 +8,7 @@ import { formatFileName } from './program-sample-registration/util';
 import { Row, Col } from 'react-grid-system';
 import { useTheme } from 'uikit/ThemeProvider';
 import { HtmlHTMLAttributes } from 'react';
-import { GATEWAY_API_ROOT } from 'global/config';
+import { getConfig } from 'global/config';
 
 export const containerStyle = css`
   padding: 8px;
@@ -143,5 +143,7 @@ export const TableInfoHeaderContainer = ({
   );
 };
 
-export const downloadTsvFileTemplate = (fileName: string) =>
+export const downloadTsvFileTemplate = (fileName: string) => {
+  const { GATEWAY_API_ROOT } = getConfig();
   window.location.assign(urlJoin(GATEWAY_API_ROOT, `clinical/template/${fileName}`));
+};

--- a/components/pages/submission-system/program-sample-registration/Instructions/index.tsx
+++ b/components/pages/submission-system/program-sample-registration/Instructions/index.tsx
@@ -1,5 +1,4 @@
 import { CONTACT_PAGE_PATH } from 'global/constants/pages';
-import getConfig from 'next/config';
 import Link from 'next/link';
 import * as React from 'react';
 import { css } from 'uikit';
@@ -20,7 +19,6 @@ import {
   downloadTsvFileTemplate,
 } from '../../common';
 import FileSelectButton from 'uikit/FileSelectButton';
-import { GATEWAY_API_ROOT } from 'global/config';
 
 function Instructions({
   registrationEnabled,

--- a/global/config.ts
+++ b/global/config.ts
@@ -1,12 +1,21 @@
 import urlJoin from 'url-join';
+import getNextConfig from 'next/config';
 
-export const GATEWAY_API_ROOT = process.env.GATEWAY_API_ROOT || 'http://localhost:9000';
-export const EGO_API_ROOT = process.env.EGO_API_ROOT || '';
-export const EGO_CLIENT_ID = process.env.EGO_CLIENT_ID || '';
-export const EGO_PUBLIC_KEY = (
-  process.env.EGO_PUBLIC_KEY ||
-  `-----BEGIN PUBLIC KEY-----\r\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0lOqMuPLCVusc6szklNXQL1FHhSkEgR7An+8BllBqTsRHM4bRYosseGFCbYPn8r8FsWuMDtxp0CwTyMQR2PCbJ740DdpbE1KC6jAfZxqcBete7gP0tooJtbvnA6X4vNpG4ukhtUoN9DzNOO0eqMU0Rgyy5HjERdYEWkwTNB30i9I+nHFOSj4MGLBSxNlnuo3keeomCRgtimCx+L/K3HNo0QHTG1J7RzLVAchfQT0lu3pUJ8kB+UM6/6NG+fVyysJyRZ9gadsr4gvHHckw8oUBp2tHvqBEkEdY+rt1Mf5jppt7JUV7HAPLB/qR5jhALY2FX/8MN+lPLmb/nLQQichVQIDAQAB\r\n-----END PUBLIC KEY-----`
-).replace(/\\n/g, '\n');
-export const AUTH_DISABLED = process.env.AUTH_DISABLED === 'true';
-export const GA_TRACKING_ID = process.env.GA_TRACKING_ID || '';
-export const EGO_URL = urlJoin(EGO_API_ROOT, `/api/oauth/login/google?client_id=${EGO_CLIENT_ID}`);
+export const getConfig = () => {
+  const publicConfig: { [k: string]: string } = getNextConfig().publicRuntimeConfig;
+  return {
+    GATEWAY_API_ROOT: publicConfig.GATEWAY_API_ROOT || 'http://localhost:9000',
+    EGO_API_ROOT: publicConfig.EGO_API_ROOT || '',
+    EGO_CLIENT_ID: publicConfig.EGO_CLIENT_ID || '',
+    EGO_PUBLIC_KEY: (
+      publicConfig.EGO_PUBLIC_KEY ||
+      `-----BEGIN PUBLIC KEY-----\r\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0lOqMuPLCVusc6szklNXQL1FHhSkEgR7An+8BllBqTsRHM4bRYosseGFCbYPn8r8FsWuMDtxp0CwTyMQR2PCbJ740DdpbE1KC6jAfZxqcBete7gP0tooJtbvnA6X4vNpG4ukhtUoN9DzNOO0eqMU0Rgyy5HjERdYEWkwTNB30i9I+nHFOSj4MGLBSxNlnuo3keeomCRgtimCx+L/K3HNo0QHTG1J7RzLVAchfQT0lu3pUJ8kB+UM6/6NG+fVyysJyRZ9gadsr4gvHHckw8oUBp2tHvqBEkEdY+rt1Mf5jppt7JUV7HAPLB/qR5jhALY2FX/8MN+lPLmb/nLQQichVQIDAQAB\r\n-----END PUBLIC KEY-----`
+    ).replace(/\\n/g, '\n'),
+    AUTH_DISABLED: publicConfig.AUTH_DISABLED === 'true',
+    GA_TRACKING_ID: publicConfig.GA_TRACKING_ID || '',
+    EGO_URL: urlJoin(
+      publicConfig.EGO_API_ROOT,
+      `/api/oauth/login/google?client_id=${publicConfig.EGO_CLIENT_ID}`,
+    ) as string,
+  };
+};

--- a/global/config.ts
+++ b/global/config.ts
@@ -14,8 +14,16 @@ export const getConfig = () => {
     AUTH_DISABLED: publicConfig.AUTH_DISABLED === 'true',
     GA_TRACKING_ID: publicConfig.GA_TRACKING_ID || '',
     EGO_URL: urlJoin(
-      publicConfig.EGO_API_ROOT,
-      `/api/oauth/login/google?client_id=${publicConfig.EGO_CLIENT_ID}`,
-    ) as string,
+      publicConfig.EGO_API_ROOT || '',
+      `/api/oauth/login/google?client_id=${publicConfig.EGO_CLIENT_ID || ''}`,
+    ),
+  } as {
+    GATEWAY_API_ROOT: string;
+    EGO_API_ROOT: string;
+    EGO_CLIENT_ID: string;
+    EGO_PUBLIC_KEY: string;
+    AUTH_DISABLED: boolean;
+    GA_TRACKING_ID: string;
+    EGO_URL: string;
   };
 };

--- a/global/hooks/useAuthContext.tsx
+++ b/global/hooks/useAuthContext.tsx
@@ -5,7 +5,7 @@ import Cookies from 'js-cookie';
 import { useRouter } from 'next/router';
 import * as React from 'react';
 import urlJoin from 'url-join';
-import { EGO_CLIENT_ID, EGO_API_ROOT } from 'global/config';
+import { getConfig } from 'global/config';
 
 type UseEgoTokenInput = {
   onError?: (error: Error) => void;
@@ -32,6 +32,7 @@ export function AuthProvider({
   egoJwt?: string;
   children: React.ReactElement;
 }) {
+  const { EGO_API_ROOT, EGO_CLIENT_ID } = getConfig();
   const egoLoginUrl = urlJoin(EGO_API_ROOT, `/api/oauth/ego-token?client_id=${EGO_CLIENT_ID}`);
   const tokenRefreshUrl = urlJoin(
     EGO_API_ROOT,

--- a/global/utils/egoJwt/index.tsx
+++ b/global/utils/egoJwt/index.tsx
@@ -1,11 +1,10 @@
 import jwtDecode from 'jwt-decode';
 import memoize from 'lodash/memoize';
-import getConfig from 'next/config';
 
 import createEgoUtils from '@icgc-argo/ego-token-utils/dist/lib/ego-token-utils';
-import { EGO_PUBLIC_KEY } from 'global/config';
+import { getConfig } from 'global/config';
 
-const TokenUtils = createEgoUtils(EGO_PUBLIC_KEY);
+const TokenUtils = createEgoUtils(getConfig().EGO_PUBLIC_KEY);
 
 type EgoJwtData = {
   iat: number;

--- a/global/utils/getApolloCacheForQueries.tsx
+++ b/global/utils/getApolloCacheForQueries.tsx
@@ -3,11 +3,12 @@ import { createHttpLink } from 'apollo-link-http';
 import fetch from 'isomorphic-fetch';
 import urlJoin from 'url-join';
 import createInMemoryCache from './createInMemoryCache';
-import { GATEWAY_API_ROOT } from 'global/config';
+import { getConfig } from 'global/config';
 
 export default (queries: Array<{ query: any; variables?: { [key: string]: any } }>) => async (
   egoJwt?: string,
 ) => {
+  const { GATEWAY_API_ROOT } = getConfig();
   const apolloClient = new ApolloClient({
     ssrMode: typeof window === 'undefined',
     // $FlowFixMe apollo-client and apollo-link-http have a type conflict in their typing

--- a/next.config.js
+++ b/next.config.js
@@ -29,8 +29,7 @@ module.exports = withImages({
 
     return config;
   },
-
-  env: {
+  publicRuntimeConfig: {
     GATEWAY_API_ROOT: process.env.GATEWAY_API_ROOT,
     EGO_API_ROOT: process.env.EGO_API_ROOT,
     EGO_CLIENT_ID: process.env.EGO_CLIENT_ID,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,6 @@ import Router from 'next/router';
 import * as React from 'react';
 import ReactGA from 'react-ga';
 import { ERROR_STATUS_KEY } from './_error';
-import getConfig from 'next/config';
 import App, { AppContext } from 'next/app';
 
 import {
@@ -17,7 +16,7 @@ import {
   ClientSideGetInitialPropsContext,
 } from 'global/utils/pages/types';
 import { NextPageContext } from 'next';
-import { AUTH_DISABLED, GA_TRACKING_ID } from 'global/config';
+import { getConfig } from 'global/config';
 
 const redirect = (res, url: string) => {
   if (res) {
@@ -58,6 +57,7 @@ class Root extends App<{
   static async getInitialProps({ Component, ctx }: AppContext & { Component: PageWithConfig }) {
     const egoJwt: string | undefined = nextCookies(ctx)[EGO_JWT_KEY];
     const { res } = ctx;
+    const { AUTH_DISABLED } = getConfig();
 
     if (egoJwt) {
       if (!isValidJwt(egoJwt)) {
@@ -111,6 +111,7 @@ class Root extends App<{
   componentDidMount() {
     const { ctx, egoJwt } = this.props;
     const userModel = decodeToken(egoJwt);
+    const { GA_TRACKING_ID } = getConfig();
 
     ReactGA.initialize(GA_TRACKING_ID, {
       gaOptions: {


### PR DESCRIPTION
Using `env` in next-config requires the env vars to be injected at build-time, which @d8660091 provided some great arguments against :). This PR creates a custom wrap around `getConfig` that gives static types so envs are read at run time but accessed with type safety.