### PR TITLE
🐛 improves the signoff without update flow

### DIFF
--- a/components/pages/submission-system/program-clinical-submission/SignOffValidationModal.tsx
+++ b/components/pages/submission-system/program-clinical-submission/SignOffValidationModal.tsx
@@ -39,8 +39,10 @@ export default ({
   onCloseClick,
   onActionClick,
   onCancelClick,
+  hasUpdate,
 }: {
   clinicalSubmissions: GqlClinicalSubmissionData;
+  hasUpdate: boolean;
   onCloseClick: React.ComponentProps<typeof Modal>['onCloseClick'];
   onActionClick: React.ComponentProps<typeof Modal>['onActionClick'];
   onCancelClick: React.ComponentProps<typeof Modal>['onCancelClick'];
@@ -48,15 +50,23 @@ export default ({
   return (
     <Modal
       actionButtonText="yes, sign off"
-      title="Are you sure you want to sign-off your clinical submission?"
+      title={
+        <span
+          css={css`
+            padding-right: 20px;
+          `}
+        >
+          Are you sure you want to sign-off your clinical submission?
+        </span>
+      }
       onCloseClick={onCloseClick}
       onActionClick={onActionClick}
       onCancelClick={onCancelClick}
     >
       <div>
-        The DCC will be notified of the following updates to previously released data and your
-        submission will be locked. Once your submission is approved by the DCC, your clinical data
-        will be placed in a queue for the next release.
+        {hasUpdate
+          ? 'The DCC will be notified of the following updates to previously released data and your submission will be locked. Once your submission is approved by the DCC, your clinical data will be placed in a queue for the next release.'
+          : 'The clinical data in your workspace will be placed in a queue for the next release.'}
       </div>
       <div
         css={css`

--- a/components/pages/submission-system/program-clinical-submission/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/index.tsx
@@ -154,6 +154,9 @@ export default function ProgramClinicalSubmission() {
   const isReadyForValidation = hasSomeEntity && !hasSchemaError;
   const isReadyForSignoff = isReadyForValidation && data.clinicalSubmissions.state === 'VALID';
   const isPendingApproval = data.clinicalSubmissions.state === 'PENDING_APPROVAL';
+  const hasUpdate = data.clinicalSubmissions.clinicalEntities.some(
+    clinicalEntity => !!clinicalEntity.dataUpdates.length,
+  );
 
   const onErrorClose: (
     index: number,
@@ -222,13 +225,15 @@ export default function ProgramClinicalSubmission() {
         });
         if (newData.clinicalSubmissions.state === null) {
           router.push(PROGRAM_DASHBOARD_PATH.replace(PROGRAM_SHORT_NAME_PATH, programShortName));
+        } else {
+          setPageLoaderShown(false);
         }
       }
     } catch (err) {
       await refetch();
       showReloadToast();
+      setPageLoaderShown(false);
     }
-    setPageLoaderShown(false);
   };
 
   return (
@@ -236,6 +241,7 @@ export default function ProgramClinicalSubmission() {
       {signOffModalShown && (
         <ModalPortal>
           <SignOffValidationModal
+            hasUpdate={hasUpdate}
             clinicalSubmissions={data.clinicalSubmissions}
             onActionClick={onSignOffApproved}
             onCloseClick={onSignOffCanceled}


### PR DESCRIPTION
**Description of changes**
- Modal content is slightly different for sign off with / without update
- Don't hide the spinner during sign off if going to redirect (next's redirect is async but somehow can't be awaited...)

**Type of Change**

- [x] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
