### PR TITLE
✨ sets selected clinical submission after action

### DIFF
--- a/components/pages/submission-system/program-clinical-submission/FilesNavigator/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/FilesNavigator/index.tsx
@@ -28,27 +28,6 @@ export default ({
 }) => {
   const isPendingApproval = submissionState === 'PENDING_APPROVAL';
   const toaster = useToaster();
-  const getDefaultFocusIndex = () => {
-    const fileToFocusOn = head(
-      orderBy(fileStates, file => {
-        switch (file.status) {
-          case 'ERROR':
-            return 0;
-          case 'UPDATE':
-            return 1;
-          case 'WARNING':
-            return 2;
-          case 'SUCCESS':
-            return 3;
-          case 'NONE':
-            return fileStates.length;
-          default:
-            return fileStates.length;
-        }
-      }),
-    );
-    return fileStates.indexOf(fileToFocusOn);
-  };
   const onFileClick = (clinicalType: string) => e => {
     onFileSelect(fileStates.findIndex(file => clinicalType === file.clinicalType));
   };

--- a/components/pages/submission-system/program-clinical-submission/FilesNavigator/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/FilesNavigator/index.tsx
@@ -10,6 +10,8 @@ import NoData from 'uikit/NoData';
 import ErrorNotification from '../ErrorNotification';
 import Button from 'uikit/Button';
 import noDataSvg from 'static/illustration_heart.svg';
+import orderBy from 'lodash/orderBy';
+import head from 'lodash/head';
 
 export default ({
   fileStates,
@@ -22,7 +24,31 @@ export default ({
 }) => {
   const isPendingApproval = submissionState === 'PENDING_APPROVAL';
   const toaster = useToaster();
-  const [selectedFileIndex, setSelectedFileIndex] = React.useState<number>(0);
+  const getDefaultFocusIndex = () => {
+    const fileToFocusOn = head(
+      orderBy(fileStates, file => {
+        switch (file.status) {
+          case 'ERROR':
+            return 0;
+          case 'UPDATE':
+            return 1;
+          case 'WARNING':
+            return 2;
+          case 'SUCCESS':
+            return 3;
+          case 'NONE':
+            return fileStates.length;
+          default:
+            return fileStates.length;
+        }
+      }),
+    );
+    return fileStates.indexOf(fileToFocusOn);
+  };
+  const [selectedFileIndex, setSelectedFileIndex] = React.useState<number>(getDefaultFocusIndex());
+  React.useEffect(() => {
+    setSelectedFileIndex(getDefaultFocusIndex());
+  }, [fileStates]);
   const onFileClick = (clinicalType: string) => e => {
     setSelectedFileIndex(fileStates.findIndex(file => clinicalType === file.clinicalType));
   };

--- a/components/pages/submission-system/program-clinical-submission/FilesNavigator/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/FilesNavigator/index.tsx
@@ -17,10 +17,14 @@ export default ({
   fileStates,
   clearDataError,
   submissionState,
+  selectedFileIndex,
+  onFileSelect,
 }: {
   submissionState: ClinicalSubmissionQueryData['clinicalSubmissions']['state'];
   fileStates: Array<ClinicalSubmissionEntityFile>;
   clearDataError: (file: ClinicalSubmissionEntityFile) => Promise<any>;
+  selectedFileIndex: number;
+  onFileSelect: (i: number) => void;
 }) => {
   const isPendingApproval = submissionState === 'PENDING_APPROVAL';
   const toaster = useToaster();
@@ -45,12 +49,8 @@ export default ({
     );
     return fileStates.indexOf(fileToFocusOn);
   };
-  const [selectedFileIndex, setSelectedFileIndex] = React.useState<number>(getDefaultFocusIndex());
-  React.useEffect(() => {
-    setSelectedFileIndex(getDefaultFocusIndex());
-  }, [fileStates]);
   const onFileClick = (clinicalType: string) => e => {
-    setSelectedFileIndex(fileStates.findIndex(file => clinicalType === file.clinicalType));
+    onFileSelect(fileStates.findIndex(file => clinicalType === file.clinicalType));
   };
   const selectedFile = fileStates[selectedFileIndex];
   const onClearClick = () => {

--- a/components/pages/submission-system/program-clinical-submission/Header.tsx
+++ b/components/pages/submission-system/program-clinical-submission/Header.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { css } from 'uikit';
+import TitleBar from 'uikit/TitleBar';
+import Progress from 'uikit/Progress';
+import { Row } from 'react-grid-system';
+import Link from 'uikit/Link';
+import Button from 'uikit/Button';
+
+export default ({
+  programShortName,
+  showProgress,
+  progressStates,
+  isPendingApproval,
+}: {
+  programShortName: string;
+  showProgress: boolean;
+  progressStates: {
+    upload: React.ComponentProps<typeof Progress.Item>['state'];
+    validate: React.ComponentProps<typeof Progress.Item>['state'];
+    signOff: React.ComponentProps<typeof Progress.Item>['state'];
+  };
+  isPendingApproval: boolean;
+}) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+      `}
+    >
+      <TitleBar>
+        <>{programShortName}</>
+        <Row nogutter align="center">
+          <div
+            css={css`
+              margin-right: 20px;
+            `}
+          >
+            Submit Clinical Data
+          </div>
+          {!showProgress && (
+            <Progress>
+              <Progress.Item text="Upload" state={progressStates.upload} />
+              <Progress.Item text="Validate" state={progressStates.validate} />
+              <Progress.Item text="Sign Off" state={progressStates.signOff} />
+              {isPendingApproval && (
+                <Progress.Item
+                  css={css`
+                    width: 100px;
+                  `}
+                  text="Pending Approval"
+                  state="locked"
+                />
+              )}
+            </Progress>
+          )}
+        </Row>
+      </TitleBar>
+      <Row nogutter align="center">
+        {!isPendingApproval && (
+          <Button
+            variant="text"
+            disabled
+            css={css`
+              margin-right: 10px;
+            `}
+          >
+            Clear submission
+          </Button>
+        )}
+        <Link
+          bold
+          withChevron
+          uppercase
+          underline={false}
+          css={css`
+            font-size: 14px;
+          `}
+        >
+          HELP
+        </Link>
+      </Row>
+    </div>
+  );
+};

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -1,0 +1,426 @@
+import * as React from 'react';
+import { css } from 'uikit';
+import { usePageQuery } from 'global/hooks/usePageContext';
+import Instruction from './Instruction';
+import Container from 'uikit/Container';
+import { containerStyle } from '../common';
+import FilesNavigator from './FilesNavigator';
+import {
+  ClinicalSubmissionEntityFile,
+  GqlClinicalEntity,
+  ClinicalSubmissionQueryData,
+  ValidateSubmissionMutationVariables,
+  UploadFilesMutationVariables,
+  SignOffSubmissionMutationVariables,
+} from './types';
+import Notification from 'uikit/notifications/Notification';
+import CLINICAL_SUBMISSION_QUERY from './gql/CLINICAL_SUBMISSION_QUERY.gql';
+import UPLOAD_CLINICAL_SUBMISSION from './gql/UPLOAD_CLINICAL_SUBMISSION.gql';
+import VALIDATE_SUBMISSION_MUTATION from './gql/VALIDATE_SUBMISSION_MUTATION.gql';
+import SIGN_OFF_SUBMISSION_MUTATION from './gql/SIGN_OFF_SUBMISSION_MUTATION.gql';
+import { useQuery, useMutation } from '@apollo/react-hooks';
+import DnaLoader from 'uikit/DnaLoader';
+import { displayDateAndTime } from 'global/utils/common';
+import { capitalize } from 'global/utils/stringUtils';
+import { useToaster } from 'global/hooks/toaster';
+import ErrorNotification from './ErrorNotification';
+import { ModalPortal } from 'components/ApplicationRoot';
+import SignOffValidationModal, { useSignOffValidationModalState } from './SignOffValidationModal';
+import SubmissionSummaryTable from './SubmissionSummaryTable';
+import Typography from 'uikit/Typography';
+import { sleep } from 'global/utils/common';
+import { useRouter } from 'next/router';
+import { PROGRAM_DASHBOARD_PATH, PROGRAM_SHORT_NAME_PATH } from 'global/constants/pages';
+import orderBy from 'lodash/orderBy';
+import head from 'lodash/head';
+import map from 'lodash/map';
+import memoize from 'lodash/memoize';
+import uniq from 'lodash/uniq';
+
+const gqlClinicalEntityToClinicalSubmissionEntityFile = (
+  submissionState: ClinicalSubmissionQueryData['clinicalSubmissions']['state'],
+) => (gqlFile: GqlClinicalEntity): ClinicalSubmissionEntityFile => {
+  const isSubmissionValidated =
+    submissionState === 'INVALID' ||
+    submissionState === 'VALID' ||
+    submissionState === 'PENDING_APPROVAL';
+  const isPendingApproval = submissionState === 'PENDING_APPROVAL';
+  const stats = {
+    errorsFound: [],
+    new: [],
+    noUpdate: [],
+    updated: [],
+    ...(gqlFile.stats || {}),
+  };
+  const hasSchemaError = !!gqlFile.schemaErrors.length;
+  const hasDataError = !!gqlFile.dataErrors.length;
+  const hasUpdate = !!stats.updated.length;
+  return {
+    stats,
+    createdAt: gqlFile.createdAt,
+    creator: gqlFile.creator,
+    fileName: gqlFile.batchName,
+    schemaErrors: gqlFile.schemaErrors,
+    dataErrors: gqlFile.dataErrors,
+    dataUpdates: gqlFile.dataUpdates,
+    displayName: capitalize((gqlFile.clinicalType || '').split('_').join(' ')),
+    clinicalType: gqlFile.clinicalType,
+    records: gqlFile.records,
+    recordsCount: gqlFile.records.length,
+    status: isPendingApproval
+      ? hasUpdate
+        ? 'UPDATE'
+        : 'SUCCESS'
+      : hasSchemaError || hasDataError
+      ? 'ERROR'
+      : !!gqlFile.records && isSubmissionValidated
+      ? 'SUCCESS'
+      : 'WARNING',
+  };
+};
+
+export default () => {
+  const { shortName: programShortName } = usePageQuery<{ shortName: string }>();
+  const [pageLoaderShown, setPageLoaderShown] = React.useState<boolean>(false);
+  const router = useRouter();
+  const [currentFileList, setCurrentFileList] = React.useState<FileList | null>(null);
+  const {
+    signOffModalShown,
+    getUserApproval,
+    onApprove: onSignOffApproved,
+    onCancel: onSignOffCanceled,
+  } = useSignOffValidationModalState();
+  const toaster = useToaster();
+
+  const placeHolderResponse: ClinicalSubmissionQueryData = {
+    clinicalSubmissions: {
+      version: '',
+      clinicalEntities: [],
+      fileErrors: [],
+      id: '',
+      state: 'OPEN',
+      updatedAt: '',
+      updatedBy: '',
+      __typename: 'ClinicalSubmissionData',
+    },
+  };
+
+  const {
+    data = placeHolderResponse,
+    loading: loadingClinicalSubmission,
+    updateQuery: updateClinicalSubmissionQuery,
+    refetch,
+  } = useQuery<ClinicalSubmissionQueryData>(CLINICAL_SUBMISSION_QUERY, {
+    variables: {
+      programShortName,
+    },
+  });
+
+  const fileNavigatorFiles = map(
+    orderBy(data.clinicalSubmissions.clinicalEntities, e => e.clinicalType),
+    gqlClinicalEntityToClinicalSubmissionEntityFile(data.clinicalSubmissions.state),
+  );
+
+  const getDefaultClinicalEntityFocus = memoize(() => {
+    const fileToClinicalEntityType = (file: File): string =>
+      data.clinicalSubmissions.clinicalEntities
+        .map(e => e.clinicalType)
+        .find(entityType => !!file.name.match(new RegExp(`^${entityType}.*\\.tsv`)));
+    const lastUploadedEntityTypes = uniq(map(currentFileList, fileToClinicalEntityType));
+    const fileToFocusOn = head(
+      orderBy(fileNavigatorFiles, file => {
+        const wasLastUploaded = lastUploadedEntityTypes.includes(file.clinicalType);
+        switch (file.status) {
+          case 'ERROR':
+            return wasLastUploaded ? 0 : fileNavigatorFiles.length;
+          case 'UPDATE':
+            return wasLastUploaded ? 1 : fileNavigatorFiles.length;
+          case 'WARNING':
+            return wasLastUploaded ? 2 : fileNavigatorFiles.length;
+          case 'SUCCESS':
+            return wasLastUploaded ? 3 : fileNavigatorFiles.length;
+          case 'NONE':
+            return fileNavigatorFiles.length;
+          default:
+            return fileNavigatorFiles.length;
+        }
+      }),
+    );
+    return fileNavigatorFiles.length ? fileNavigatorFiles.indexOf(fileToFocusOn) : 0;
+  });
+  const [selectedClinicalEntityIndex, setSelectedClinicalEntityIndex] = React.useState<number>(
+    getDefaultClinicalEntityFocus(),
+  );
+
+  const [uploadClinicalSubmission] = useMutation<
+    ClinicalSubmissionQueryData,
+    UploadFilesMutationVariables
+  >(UPLOAD_CLINICAL_SUBMISSION, {
+    onCompleted: () => {
+      setSelectedClinicalEntityIndex(getDefaultClinicalEntityFocus());
+    },
+  });
+  const [validateSubmission] = useMutation<
+    ClinicalSubmissionQueryData,
+    ValidateSubmissionMutationVariables
+  >(VALIDATE_SUBMISSION_MUTATION);
+  const [signOffSubmission] = useMutation<
+    ClinicalSubmissionQueryData,
+    SignOffSubmissionMutationVariables
+  >(SIGN_OFF_SUBMISSION_MUTATION);
+
+  const allDataErrors = React.useMemo(
+    () =>
+      data.clinicalSubmissions.clinicalEntities.reduce<
+        React.ComponentProps<typeof ErrorNotification>['errors']
+      >(
+        (acc, entity) => [
+          ...acc,
+          ...entity.dataErrors.map(err => ({
+            ...err,
+            fileName: entity.batchName,
+          })),
+        ],
+        [],
+      ),
+    [data],
+  );
+
+  const hasDataError = !!allDataErrors.length;
+  const hasSchemaError =
+    !!data.clinicalSubmissions.clinicalEntities.length &&
+    data.clinicalSubmissions.clinicalEntities.some(({ schemaErrors }) => !!schemaErrors.length);
+  const hasSomeEntity = data.clinicalSubmissions.clinicalEntities.some(
+    ({ records }) => !!records.length,
+  );
+  const isReadyForValidation = hasSomeEntity && !hasSchemaError;
+  const isReadyForSignoff = isReadyForValidation && data.clinicalSubmissions.state === 'VALID';
+  const isPendingApproval = data.clinicalSubmissions.state === 'PENDING_APPROVAL';
+  const hasUpdate = data.clinicalSubmissions.clinicalEntities.some(
+    clinicalEntity => !!clinicalEntity.dataUpdates.length,
+  );
+  const isValidated = data.clinicalSubmissions.state !== 'OPEN';
+
+  const onErrorClose: (
+    index: number,
+  ) => React.ComponentProps<typeof Notification>['onInteraction'] = index => ({ type }) => {
+    if (type === 'CLOSE') {
+      updateClinicalSubmissionQuery(previous => ({
+        ...previous,
+        clinicalSubmissions: {
+          ...previous.clinicalSubmissions,
+          fileErrors: previous.clinicalSubmissions.fileErrors.filter((_, i) => i !== index),
+        },
+      }));
+    }
+  };
+
+  const handleSubmissionFilesUpload = (files: FileList) => {
+    setCurrentFileList(files);
+    return uploadClinicalSubmission({
+      variables: {
+        files,
+        programShortName,
+      },
+    });
+  };
+
+  const handleDataErrorClearance = () => {
+    toaster.addToast({
+      title: 'Clearing errors!',
+      content: "I'm just a dummy placeholder behaviour",
+    });
+  };
+
+  const showReloadToast = () => {
+    toaster.addToast({
+      variant: 'ERROR',
+      title: 'Something went wrong',
+      content: 'Uh oh! It looks like something went wrong. This page has been reloaded.',
+    });
+  };
+
+  const handleSubmissionValidation = async () => {
+    try {
+      await validateSubmission({
+        variables: {
+          programShortName,
+          submissionVersion: data.clinicalSubmissions.version,
+        },
+      });
+    } catch (err) {
+      await refetch();
+      showReloadToast();
+    }
+  };
+
+  const handleClearSchemaError: React.ComponentProps<
+    typeof FilesNavigator
+  >['clearDataError'] = async file => {
+    await updateClinicalSubmissionQuery(previous => ({
+      ...previous,
+      clinicalSubmissions: {
+        ...previous.clinicalSubmissions,
+        clinicalEntities: previous.clinicalSubmissions.clinicalEntities.map(entity => ({
+          ...entity,
+          schemaErrors: file.clinicalType === entity.clinicalType ? [] : entity.schemaErrors,
+        })),
+      },
+    }));
+  };
+
+  const handleSignOff = async () => {
+    try {
+      const userDidApprove = await getUserApproval();
+      if (userDidApprove) {
+        setPageLoaderShown(true);
+        await sleep();
+        const { data: newData } = await signOffSubmission({
+          variables: {
+            programShortName,
+            submissionVersion: data.clinicalSubmissions.version,
+          },
+        });
+        if (newData.clinicalSubmissions.state === null) {
+          router.push(PROGRAM_DASHBOARD_PATH.replace(PROGRAM_SHORT_NAME_PATH, programShortName));
+        } else {
+          setPageLoaderShown(false);
+        }
+      }
+    } catch (err) {
+      await refetch();
+      showReloadToast();
+      setPageLoaderShown(false);
+    }
+  };
+
+  return (
+    <>
+      {signOffModalShown && (
+        <ModalPortal>
+          <SignOffValidationModal
+            hasUpdate={hasUpdate}
+            clinicalSubmissions={data.clinicalSubmissions}
+            onActionClick={onSignOffApproved}
+            onCloseClick={onSignOffCanceled}
+            onCancelClick={onSignOffCanceled}
+          />
+        </ModalPortal>
+      )}
+      {pageLoaderShown && (
+        <ModalPortal>
+          <DnaLoader />
+        </ModalPortal>
+      )}
+      {!isPendingApproval && !loadingClinicalSubmission && (
+        <Container css={containerStyle}>
+          <Instruction
+            uploadEnabled
+            signOffEnabled={isReadyForSignoff}
+            validationEnabled={isReadyForValidation && !hasDataError && !isValidated}
+            onUploadFileSelect={handleSubmissionFilesUpload}
+            onValidateClick={handleSubmissionValidation}
+            onSignOffClick={handleSignOff}
+            clinicalTypes={data.clinicalSubmissions.clinicalEntities.map(
+              ({ clinicalType }) => clinicalType,
+            )}
+          />
+        </Container>
+      )}
+      {isPendingApproval && !loadingClinicalSubmission && (
+        <Container
+          css={css`
+            padding: 24px;
+          `}
+        >
+          <div
+            css={css`
+              padding-bottom: 8px;
+              display: flex;
+              justify-content: space-between;
+              align-items: center;
+            `}
+          >
+            <Typography
+              variant="subtitle"
+              color="primary"
+              css={css`
+                margin: 0px;
+              `}
+            >
+              Submission Summary
+            </Typography>
+            <Typography variant="data" color="black" as="div">
+              Signed off on{' '}
+              <strong>{displayDateAndTime(data.clinicalSubmissions.updatedAt)}</strong> by{' '}
+              <strong>{data.clinicalSubmissions.updatedBy}</strong>
+            </Typography>
+          </div>
+          <SubmissionSummaryTable clinicalSubmissions={data.clinicalSubmissions} />
+        </Container>
+      )}
+      {data.clinicalSubmissions.fileErrors.map(({ fileNames, msg }, i) => (
+        <Notification
+          key={i}
+          css={css`
+            margin-top: 20px;
+          `}
+          size="SM"
+          variant="ERROR"
+          interactionType="CLOSE"
+          title={`${fileNames.length} of ${
+            (currentFileList || []).length
+          } files failed to upload: ${fileNames.join(', ')}`}
+          content={msg}
+          onInteraction={onErrorClose(i)}
+        />
+      ))}
+      {hasDataError && (
+        <div
+          css={css`
+            margin-top: 20px;
+          `}
+        >
+          <ErrorNotification
+            showClinicalType
+            onClearClick={handleDataErrorClearance}
+            title={`${allDataErrors.length} errors found in submission workspace`}
+            subtitle="Your submission cannot yet be signed off and sent to DCC. Please correct the following errors and reupload the corresponding files."
+            errors={allDataErrors}
+          />
+        </div>
+      )}
+      <Container
+        css={css`
+          ${containerStyle}
+          min-height: 100px;
+          position: relative;
+          padding: 0px;
+          min-height: calc(100vh - 240px);
+          display: flex;
+        `}
+      >
+        {loadingClinicalSubmission ? (
+          <div
+            css={css`
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              width: 100%;
+            `}
+          >
+            <DnaLoader />
+          </div>
+        ) : (
+          <FilesNavigator
+            submissionState={data.clinicalSubmissions.state}
+            clearDataError={handleClearSchemaError}
+            fileStates={fileNavigatorFiles}
+            selectedFileIndex={selectedClinicalEntityIndex}
+            onFileSelect={setSelectedClinicalEntityIndex}
+          />
+        )}
+      </Container>
+    </>
+  );
+};

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -113,7 +113,7 @@ export default () => {
   } = useQuery<ClinicalSubmissionQueryData>(CLINICAL_SUBMISSION_QUERY, {
     variables: {
       programShortName,
-    },
+    }
   });
 
   const fileNavigatorFiles = map(
@@ -121,9 +121,9 @@ export default () => {
     gqlClinicalEntityToClinicalSubmissionEntityFile(data.clinicalSubmissions.state),
   );
 
-  const getDefaultClinicalEntityFocus = memoize(() => {
+  const getDefaultClinicalEntityIndex = memoize((_data: typeof data = data) => {
     const fileToClinicalEntityType = (file: File): string =>
-      data.clinicalSubmissions.clinicalEntities
+      _data.clinicalSubmissions.clinicalEntities
         .map(e => e.clinicalType)
         .find(entityType => !!file.name.match(new RegExp(`^${entityType}.*\\.tsv`)));
     const lastUploadedEntityTypes = uniq(map(currentFileList, fileToClinicalEntityType));
@@ -149,7 +149,7 @@ export default () => {
     return fileNavigatorFiles.length ? fileNavigatorFiles.indexOf(fileToFocusOn) : 0;
   });
   const [selectedClinicalEntityIndex, setSelectedClinicalEntityIndex] = React.useState<number>(
-    getDefaultClinicalEntityFocus(),
+    getDefaultClinicalEntityIndex(),
   );
 
   const [uploadClinicalSubmission] = useMutation<
@@ -157,7 +157,7 @@ export default () => {
     UploadFilesMutationVariables
   >(UPLOAD_CLINICAL_SUBMISSION, {
     onCompleted: () => {
-      setSelectedClinicalEntityIndex(getDefaultClinicalEntityFocus());
+      setSelectedClinicalEntityIndex(getDefaultClinicalEntityIndex());
     },
   });
   const [validateSubmission] = useMutation<

--- a/components/pages/submission-system/program-clinical-submission/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/index.tsx
@@ -131,7 +131,7 @@ export default function ProgramClinicalSubmission() {
     const fileToClinicalEntityType = (file: File): string =>
       data.clinicalSubmissions.clinicalEntities
         .map(e => e.clinicalType)
-        .find(entityType => file.name.includes(entityType));
+        .find(entityType => !!file.name.match(new RegExp(`^${entityType}.*\\.tsv`)));
     const lastUploadedEntityTypes: string[] = uniq(map(currentFileList, fileToClinicalEntityType));
     const fileToFocusOn = head(
       orderBy(fileNavigatorFiles, file => {

--- a/components/pages/submission-system/program-clinical-submission/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/index.tsx
@@ -1,102 +1,20 @@
 import * as React from 'react';
 import SubmissionLayout from '../layout';
-import { css, styled } from 'uikit';
+import { styled } from 'uikit';
 import { usePageQuery } from 'global/hooks/usePageContext';
-import Instruction from './Instruction';
-import Container from 'uikit/Container';
-import { containerStyle } from '../common';
-import FilesNavigator from './FilesNavigator';
-import {
-  ClinicalSubmissionEntityFile,
-  GqlClinicalEntity,
-  ClinicalSubmissionQueryData,
-  ValidateSubmissionMutationVariables,
-  UploadFilesMutationVariables,
-  SignOffSubmissionMutationVariables,
-} from './types';
-import Notification from 'uikit/notifications/Notification';
+import { ClinicalSubmissionQueryData } from './types';
 import CLINICAL_SUBMISSION_QUERY from './gql/CLINICAL_SUBMISSION_QUERY.gql';
-import UPLOAD_CLINICAL_SUBMISSION from './gql/UPLOAD_CLINICAL_SUBMISSION.gql';
-import VALIDATE_SUBMISSION_MUTATION from './gql/VALIDATE_SUBMISSION_MUTATION.gql';
-import SIGN_OFF_SUBMISSION_MUTATION from './gql/SIGN_OFF_SUBMISSION_MUTATION.gql';
-import { useQuery, useMutation } from '@apollo/react-hooks';
-import DnaLoader from 'uikit/DnaLoader';
-import { displayDateAndTime } from 'global/utils/common';
-import { capitalize } from 'global/utils/stringUtils';
-import { useToaster } from 'global/hooks/toaster';
+import { useQuery } from '@apollo/react-hooks';
 import ErrorNotification from './ErrorNotification';
-import { ModalPortal } from 'components/ApplicationRoot';
-import SignOffValidationModal, { useSignOffValidationModalState } from './SignOffValidationModal';
-import SubmissionSummaryTable from './SubmissionSummaryTable';
-import Typography from 'uikit/Typography';
 import { ContentHeader } from 'uikit/PageLayout';
 import { useTheme } from 'uikit/ThemeProvider';
-import { sleep } from 'global/utils/common';
-import { useRouter } from 'next/router';
-import { PROGRAM_DASHBOARD_PATH, PROGRAM_SHORT_NAME_PATH } from 'global/constants/pages';
 import Header from './Header';
-import orderBy from 'lodash/orderBy';
-import head from 'lodash/head';
-import map from 'lodash/map';
-import memoize from 'lodash/memoize';
-import uniq from 'lodash/uniq';
-import find from 'lodash/find';
-
-const gqlClinicalEntityToClinicalSubmissionEntityFile = (
-  submissionState: ClinicalSubmissionQueryData['clinicalSubmissions']['state'],
-) => (gqlFile: GqlClinicalEntity): ClinicalSubmissionEntityFile => {
-  const isSubmissionValidated =
-    submissionState === 'INVALID' ||
-    submissionState === 'VALID' ||
-    submissionState === 'PENDING_APPROVAL';
-  const isPendingApproval = submissionState === 'PENDING_APPROVAL';
-  const stats = {
-    errorsFound: [],
-    new: [],
-    noUpdate: [],
-    updated: [],
-    ...(gqlFile.stats || {}),
-  };
-  const hasSchemaError = !!gqlFile.schemaErrors.length;
-  const hasDataError = !!gqlFile.dataErrors.length;
-  const hasUpdate = !!stats.updated.length;
-  return {
-    stats,
-    createdAt: gqlFile.createdAt,
-    creator: gqlFile.creator,
-    fileName: gqlFile.batchName,
-    schemaErrors: gqlFile.schemaErrors,
-    dataErrors: gqlFile.dataErrors,
-    dataUpdates: gqlFile.dataUpdates,
-    displayName: capitalize((gqlFile.clinicalType || '').split('_').join(' ')),
-    clinicalType: gqlFile.clinicalType,
-    records: gqlFile.records,
-    recordsCount: gqlFile.records.length,
-    status: isPendingApproval
-      ? hasUpdate
-        ? 'UPDATE'
-        : 'SUCCESS'
-      : hasSchemaError || hasDataError
-      ? 'ERROR'
-      : !!gqlFile.records && isSubmissionValidated
-      ? 'SUCCESS'
-      : 'WARNING',
-  };
-};
+import PageContent from './PageContent';
 
 export default function ProgramClinicalSubmission() {
   const theme = useTheme();
   const { shortName: programShortName } = usePageQuery<{ shortName: string }>();
-  const [pageLoaderShown, setPageLoaderShown] = React.useState<boolean>(false);
-  const router = useRouter();
-  const [currentFileList, setCurrentFileList] = React.useState<FileList | null>(null);
-  const {
-    signOffModalShown,
-    getUserApproval,
-    onApprove: onSignOffApproved,
-    onCancel: onSignOffCanceled,
-  } = useSignOffValidationModalState();
-  const toaster = useToaster();
+  const [] = React.useState<FileList | null>(null);
 
   const placeHolderResponse: ClinicalSubmissionQueryData = {
     clinicalSubmissions: {
@@ -111,81 +29,29 @@ export default function ProgramClinicalSubmission() {
     },
   };
 
-  const {
-    data = placeHolderResponse,
-    loading: loadingClinicalSubmission,
-    updateQuery: updateClinicalSubmissionQuery,
-    refetch,
-  } = useQuery<ClinicalSubmissionQueryData>(CLINICAL_SUBMISSION_QUERY, {
+  const { data = placeHolderResponse, loading: loadingClinicalSubmission } = useQuery<
+    ClinicalSubmissionQueryData
+  >(CLINICAL_SUBMISSION_QUERY, {
     variables: {
       programShortName,
     },
   });
 
-  const fileNavigatorFiles = map(
-    orderBy(data.clinicalSubmissions.clinicalEntities, e => e.clinicalType),
-    gqlClinicalEntityToClinicalSubmissionEntityFile(data.clinicalSubmissions.state),
-  );
-
-  const getDefaultClinicalEntityFocus = memoize(() => {
-    const fileToClinicalEntityType = (file: File): string =>
-      data.clinicalSubmissions.clinicalEntities
-        .map(e => e.clinicalType)
-        .find(entityType => !!file.name.match(new RegExp(`^${entityType}.*\\.tsv`)));
-    const lastUploadedEntityTypes: string[] = uniq(map(currentFileList, fileToClinicalEntityType));
-    const fileToFocusOn = head(
-      orderBy(fileNavigatorFiles, file => {
-        const wasLastUploaded = lastUploadedEntityTypes.includes(file.clinicalType);
-        switch (file.status) {
-          case 'ERROR':
-            return wasLastUploaded ? 0 : fileNavigatorFiles.length;
-          case 'UPDATE':
-            return wasLastUploaded ? 1 : fileNavigatorFiles.length;
-          case 'WARNING':
-            return wasLastUploaded ? 2 : fileNavigatorFiles.length;
-          case 'SUCCESS':
-            return wasLastUploaded ? 3 : fileNavigatorFiles.length;
-          case 'NONE':
-            return fileNavigatorFiles.length;
-          default:
-            return fileNavigatorFiles.length;
-        }
-      }),
-    );
-    return fileNavigatorFiles.length ? fileNavigatorFiles.indexOf(fileToFocusOn) : 0;
-  });
-  const [selectedClinicalEntityIndex, setSelectedClinicalEntityIndex] = React.useState<number>(
-    getDefaultClinicalEntityFocus(),
-  );
-
-  const [uploadClinicalSubmission] = useMutation<
-    ClinicalSubmissionQueryData,
-    UploadFilesMutationVariables
-  >(UPLOAD_CLINICAL_SUBMISSION, {
-    onCompleted: () => {
-      setSelectedClinicalEntityIndex(getDefaultClinicalEntityFocus());
-    },
-  });
-  const [validateSubmission] = useMutation<
-    ClinicalSubmissionQueryData,
-    ValidateSubmissionMutationVariables
-  >(VALIDATE_SUBMISSION_MUTATION);
-  const [signOffSubmission] = useMutation<
-    ClinicalSubmissionQueryData,
-    SignOffSubmissionMutationVariables
-  >(SIGN_OFF_SUBMISSION_MUTATION);
-
-  const allDataErrors = data.clinicalSubmissions.clinicalEntities.reduce<
-    React.ComponentProps<typeof ErrorNotification>['errors']
-  >(
-    (acc, entity) => [
-      ...acc,
-      ...entity.dataErrors.map(err => ({
-        ...err,
-        fileName: entity.batchName,
-      })),
-    ],
-    [],
+  const allDataErrors = React.useMemo(
+    () =>
+      data.clinicalSubmissions.clinicalEntities.reduce<
+        React.ComponentProps<typeof ErrorNotification>['errors']
+      >(
+        (acc, entity) => [
+          ...acc,
+          ...entity.dataErrors.map(err => ({
+            ...err,
+            fileName: entity.batchName,
+          })),
+        ],
+        [],
+      ),
+    [data],
   );
 
   const hasDataError = !!allDataErrors.length;
@@ -203,117 +69,8 @@ export default function ProgramClinicalSubmission() {
   );
   const isValidated = data.clinicalSubmissions.state !== 'OPEN';
 
-  const onErrorClose: (
-    index: number,
-  ) => React.ComponentProps<typeof Notification>['onInteraction'] = index => ({ type }) => {
-    if (type === 'CLOSE') {
-      updateClinicalSubmissionQuery(previous => ({
-        ...previous,
-        clinicalSubmissions: {
-          ...previous.clinicalSubmissions,
-          fileErrors: previous.clinicalSubmissions.fileErrors.filter((_, i) => i !== index),
-        },
-      }));
-    }
-  };
-
-  const handleSubmissionFilesUpload = (files: FileList) => {
-    setCurrentFileList(files);
-    return uploadClinicalSubmission({
-      variables: {
-        files,
-        programShortName,
-      },
-    });
-  };
-
-  const handleDataErrorClearance = () => {
-    toaster.addToast({
-      title: 'Clearing errors!',
-      content: "I'm just a dummy placeholder behaviour",
-    });
-  };
-
-  const showReloadToast = () => {
-    toaster.addToast({
-      variant: 'ERROR',
-      title: 'Something went wrong',
-      content: 'Uh oh! It looks like something went wrong. This page has been reloaded.',
-    });
-  };
-
-  const handleSubmissionValidation = async () => {
-    try {
-      await validateSubmission({
-        variables: {
-          programShortName,
-          submissionVersion: data.clinicalSubmissions.version,
-        },
-      });
-    } catch (err) {
-      await refetch();
-      showReloadToast();
-    }
-  };
-
-  const handleClearSchemaError: React.ComponentProps<
-    typeof FilesNavigator
-  >['clearDataError'] = async file => {
-    await updateClinicalSubmissionQuery(previous => ({
-      ...previous,
-      clinicalSubmissions: {
-        ...previous.clinicalSubmissions,
-        clinicalEntities: previous.clinicalSubmissions.clinicalEntities.map(entity => ({
-          ...entity,
-          schemaErrors: file.clinicalType === entity.clinicalType ? [] : entity.schemaErrors,
-        })),
-      },
-    }));
-  };
-
-  const handleSignOff = async () => {
-    try {
-      const userDidApprove = await getUserApproval();
-      if (userDidApprove) {
-        setPageLoaderShown(true);
-        await sleep();
-        const { data: newData } = await signOffSubmission({
-          variables: {
-            programShortName,
-            submissionVersion: data.clinicalSubmissions.version,
-          },
-        });
-        if (newData.clinicalSubmissions.state === null) {
-          router.push(PROGRAM_DASHBOARD_PATH.replace(PROGRAM_SHORT_NAME_PATH, programShortName));
-        } else {
-          setPageLoaderShown(false);
-        }
-      }
-    } catch (err) {
-      await refetch();
-      showReloadToast();
-      setPageLoaderShown(false);
-    }
-  };
-
   return (
     <>
-      {signOffModalShown && (
-        <ModalPortal>
-          <SignOffValidationModal
-            hasUpdate={hasUpdate}
-            clinicalSubmissions={data.clinicalSubmissions}
-            onActionClick={onSignOffApproved}
-            onCloseClick={onSignOffCanceled}
-            onCancelClick={onSignOffCanceled}
-          />
-        </ModalPortal>
-      )}
-      {pageLoaderShown && (
-        <ModalPortal>
-          <DnaLoader />
-        </ModalPortal>
-      )}
       <SubmissionLayout
         ContentHeaderComponent={styled(ContentHeader)`
           background: ${isPendingApproval ? theme.colors.accent3_4 : theme.colors.white};
@@ -338,115 +95,7 @@ export default function ProgramClinicalSubmission() {
           />
         }
       >
-        {!isPendingApproval && !loadingClinicalSubmission && (
-          <Container css={containerStyle}>
-            <Instruction
-              uploadEnabled
-              signOffEnabled={isReadyForSignoff}
-              validationEnabled={isReadyForValidation && !hasDataError && !isValidated}
-              onUploadFileSelect={handleSubmissionFilesUpload}
-              onValidateClick={handleSubmissionValidation}
-              onSignOffClick={handleSignOff}
-              clinicalTypes={data.clinicalSubmissions.clinicalEntities.map(
-                ({ clinicalType }) => clinicalType,
-              )}
-            />
-          </Container>
-        )}
-        {isPendingApproval && !loadingClinicalSubmission && (
-          <Container
-            css={css`
-              padding: 24px;
-            `}
-          >
-            <div
-              css={css`
-                padding-bottom: 8px;
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-              `}
-            >
-              <Typography
-                variant="subtitle"
-                color="primary"
-                css={css`
-                  margin: 0px;
-                `}
-              >
-                Submission Summary
-              </Typography>
-              <Typography variant="data" color="black" as="div">
-                Signed off on{' '}
-                <strong>{displayDateAndTime(data.clinicalSubmissions.updatedAt)}</strong> by{' '}
-                <strong>{data.clinicalSubmissions.updatedBy}</strong>
-              </Typography>
-            </div>
-            <SubmissionSummaryTable clinicalSubmissions={data.clinicalSubmissions} />
-          </Container>
-        )}
-        {data.clinicalSubmissions.fileErrors.map(({ fileNames, msg }, i) => (
-          <Notification
-            key={i}
-            css={css`
-              margin-top: 20px;
-            `}
-            size="SM"
-            variant="ERROR"
-            interactionType="CLOSE"
-            title={`${fileNames.length} of ${
-              (currentFileList || []).length
-            } files failed to upload: ${fileNames.join(', ')}`}
-            content={msg}
-            onInteraction={onErrorClose(i)}
-          />
-        ))}
-        {hasDataError && (
-          <div
-            css={css`
-              margin-top: 20px;
-            `}
-          >
-            <ErrorNotification
-              showClinicalType
-              onClearClick={handleDataErrorClearance}
-              title={`${allDataErrors.length} errors found in submission workspace`}
-              subtitle="Your submission cannot yet be signed off and sent to DCC. Please correct the following errors and reupload the corresponding files."
-              errors={allDataErrors}
-            />
-          </div>
-        )}
-        <Container
-          css={css`
-            ${containerStyle}
-            min-height: 100px;
-            position: relative;
-            padding: 0px;
-            min-height: calc(100vh - 240px);
-            display: flex;
-          `}
-        >
-          {loadingClinicalSubmission ? (
-            <div
-              css={css`
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                width: 100%;
-              `}
-            >
-              <DnaLoader />
-            </div>
-          ) : (
-            <FilesNavigator
-              submissionState={data.clinicalSubmissions.state}
-              clearDataError={handleClearSchemaError}
-              fileStates={fileNavigatorFiles}
-              selectedFileIndex={selectedClinicalEntityIndex}
-              onFileSelect={setSelectedClinicalEntityIndex}
-            />
-          )}
-        </Container>
+        <PageContent />
       </SubmissionLayout>
     </>
   );

--- a/components/pages/submission-system/program-clinical-submission/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/index.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import SubmissionLayout from '../layout';
 import { css, styled } from 'uikit';
-import TitleBar from 'uikit/TitleBar';
 import { usePageQuery } from 'global/hooks/usePageContext';
-import Progress from 'uikit/Progress';
-import { Row } from 'react-grid-system';
-import Link from 'uikit/Link';
-import Button from 'uikit/Button';
 import Instruction from './Instruction';
 import Container from 'uikit/Container';
 import { containerStyle } from '../common';
@@ -39,6 +34,7 @@ import { useTheme } from 'uikit/ThemeProvider';
 import { sleep } from 'global/utils/common';
 import { useRouter } from 'next/router';
 import { PROGRAM_DASHBOARD_PATH, PROGRAM_SHORT_NAME_PATH } from 'global/constants/pages';
+import Header from './Header';
 
 const gqlClinicalEntityToClinicalSubmissionEntityFile = (
   submissionState: ClinicalSubmissionQueryData['clinicalSubmissions']['state'],
@@ -263,88 +259,23 @@ export default function ProgramClinicalSubmission() {
           background: ${isPendingApproval ? theme.colors.accent3_4 : theme.colors.white};
         `}
         contentHeader={
-          <div
-            css={css`
-              display: flex;
-              justify-content: space-between;
-              align-items: center;
-              width: 100%;
-            `}
-          >
-            <TitleBar>
-              <>{programShortName}</>
-              <Row nogutter align="center">
-                <div
-                  css={css`
-                    margin-right: 20px;
-                  `}
-                >
-                  Submit Clinical Data
-                </div>
-                {!loadingClinicalSubmission && (
-                  <Progress>
-                    <Progress.Item
-                      text="Upload"
-                      state={
-                        isReadyForValidation ? 'success' : hasSchemaError ? 'error' : 'disabled'
-                      }
-                    />
-                    <Progress.Item
-                      text="Validate"
-                      state={
-                        isReadyForSignoff || isPendingApproval
-                          ? 'success'
-                          : isReadyForValidation
-                          ? hasDataError
-                            ? 'error'
-                            : 'pending'
-                          : 'disabled'
-                      }
-                    />
-                    <Progress.Item
-                      text="Sign Off"
-                      state={
-                        isReadyForSignoff ? 'pending' : isPendingApproval ? 'success' : 'disabled'
-                      }
-                    />
-                    {isPendingApproval && (
-                      <Progress.Item
-                        css={css`
-                          width: 100px;
-                        `}
-                        text="Pending Approval"
-                        state="locked"
-                      />
-                    )}
-                  </Progress>
-                )}
-              </Row>
-            </TitleBar>
-            <Row nogutter align="center">
-              {!isPendingApproval && (
-                <Button
-                  variant="text"
-                  disabled
-                  css={css`
-                    margin-right: 10px;
-                  `}
-                >
-                  Clear submission
-                </Button>
-              )}
-              <Link
-                bold
-                withChevron
-                uppercase
-                underline={false}
-                css={css`
-                  font-size: 14px;
-                `}
-              >
-                HELP
-              </Link>
-            </Row>
-          </div>
+          <Header
+            programShortName={programShortName}
+            showProgress={!loadingClinicalSubmission}
+            isPendingApproval={isPendingApproval}
+            progressStates={{
+              upload: isReadyForValidation ? 'success' : hasSchemaError ? 'error' : 'disabled',
+              validate:
+                isReadyForSignoff || isPendingApproval
+                  ? 'success'
+                  : isReadyForValidation
+                  ? hasDataError
+                    ? 'error'
+                    : 'pending'
+                  : 'disabled',
+              signOff: isReadyForSignoff ? 'pending' : isPendingApproval ? 'success' : 'disabled',
+            }}
+          />
         }
       >
         {!isPendingApproval && !loadingClinicalSubmission && (

--- a/components/pages/submission-system/program-clinical-submission/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/index.tsx
@@ -210,6 +210,21 @@ export default function ProgramClinicalSubmission() {
     }
   };
 
+  const handleClearSchemaError: React.ComponentProps<
+    typeof FilesNavigator
+  >['clearDataError'] = async file => {
+    await updateClinicalSubmissionQuery(previous => ({
+      ...previous,
+      clinicalSubmissions: {
+        ...previous.clinicalSubmissions,
+        clinicalEntities: previous.clinicalSubmissions.clinicalEntities.map(entity => ({
+          ...entity,
+          schemaErrors: file.clinicalType === entity.clinicalType ? [] : entity.schemaErrors,
+        })),
+      },
+    }));
+  };
+
   const handleSignOff = async () => {
     try {
       const userDidApprove = await getUserApproval();
@@ -379,19 +394,7 @@ export default function ProgramClinicalSubmission() {
           ) : (
             <FilesNavigator
               submissionState={data.clinicalSubmissions.state}
-              clearDataError={async file => {
-                await updateClinicalSubmissionQuery(previous => ({
-                  ...previous,
-                  clinicalSubmissions: {
-                    ...previous.clinicalSubmissions,
-                    clinicalEntities: previous.clinicalSubmissions.clinicalEntities.map(entity => ({
-                      ...entity,
-                      schemaErrors:
-                        file.clinicalType === entity.clinicalType ? [] : entity.schemaErrors,
-                    })),
-                  },
-                }));
-              }}
+              clearDataError={handleClearSchemaError}
               fileStates={data.clinicalSubmissions.clinicalEntities.map(
                 gqlClinicalEntityToClinicalSubmissionEntityFile(data.clinicalSubmissions.state),
               )}

--- a/components/pages/submission-system/program-clinical-submission/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/index.tsx
@@ -149,7 +149,6 @@ export default function ProgramClinicalSubmission() {
   const hasSomeEntity = data.clinicalSubmissions.clinicalEntities.some(
     ({ records }) => !!records.length,
   );
-  const hasFileError = !!data.clinicalSubmissions.fileErrors.length;
   const isReadyForValidation = hasSomeEntity && !hasSchemaError;
   const isReadyForSignoff = isReadyForValidation && data.clinicalSubmissions.state === 'VALID';
   const isPendingApproval = data.clinicalSubmissions.state === 'PENDING_APPROVAL';


### PR DESCRIPTION
**Description of changes**
- splits up the index file into `Header` and `PageContent` components to keep @joneubank happy
- lifts the selected vertical tab state up from `FilesNavigator/index.tsx` to `PageContent`
- sets selected vertical tab after file upload, based on file name and priority (look for implementation and usage of `getDefaultClinicalEntityIndex`)

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
