### PR TITLE
🐛 fixes apollo client initialization to work with dev tool

### DIFF
--- a/components/ApplicationRoot.tsx
+++ b/components/ApplicationRoot.tsx
@@ -113,7 +113,7 @@ const ApolloClientProvider: React.ComponentType<{ egoJwt: string; apolloCache: a
   apolloCache,
 }) => {
   const { GATEWAY_API_ROOT } = getConfig();
-  const createNewClient = () =>
+  const createNewClient = (configs: { connectToDevTools: boolean }) =>
     new ApolloClient({
       link: createUploadLink({
         uri: urljoin(GATEWAY_API_ROOT, '/graphql'),
@@ -124,11 +124,14 @@ const ApolloClientProvider: React.ComponentType<{ egoJwt: string; apolloCache: a
             }
           : {},
       }),
+      connectToDevTools: configs.connectToDevTools,
       cache: createInMemoryCache().restore(apolloCache),
     });
-  const [client, setClient] = React.useState(createNewClient());
+  const [client, setClient] = React.useState<ReturnType<typeof createNewClient>>(
+    createNewClient({ connectToDevTools: false }),
+  );
   React.useEffect(() => {
-    setClient(createNewClient());
+    setClient(createNewClient({ connectToDevTools: true }));
   }, [egoJwt]);
   return <ApolloProvider client={client}>{children}</ApolloProvider>;
 };


### PR DESCRIPTION
**Description of changes**

We are getting multiple apollo clients created and trying to hook onto the dev tools which seems to confuse it. This ensures that only the final client gets to hook onto the dev tool.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
