### PR TITLE
Updates clinical submission approval

### DIFF
--- a/components/ApplicationRoot.tsx
+++ b/components/ApplicationRoot.tsx
@@ -75,7 +75,6 @@ const ToastProvider = ({ children }) => {
   return (
     <ToasterContext.Provider value={toaster}>
       {children}
-      <ToastDisplayArea toaster={toaster} />
       <div
         css={css`
           position: fixed;
@@ -85,6 +84,7 @@ const ToastProvider = ({ children }) => {
         `}
         ref={modalPortalRef}
       />
+      <ToastDisplayArea toaster={toaster} />
     </ToasterContext.Provider>
   );
 };

--- a/components/pages/submission-system/program-clinical-submission/Header.tsx
+++ b/components/pages/submission-system/program-clinical-submission/Header.tsx
@@ -74,7 +74,7 @@ export default ({
     const didUserConfirm = await getUserConfirmation({
       title: isDcc ? 'Reopen Submission?' : 'Are you sure you want to reopen your submission?',
       children: isDcc
-        ? 'Are you sure you want to approve this clinical submission?'
+        ? 'Are you sure you want to reopen this clinical submission?'
         : 'If you reopen your clinical submission it will be recalled from DCC approval and your workspace will be open for modifications.',
       actionButtonText: isDcc ? 'Yes, Reopen' : 'Yes, Reopen Submission',
       buttonSize: 'sm',

--- a/components/pages/submission-system/program-clinical-submission/Header.tsx
+++ b/components/pages/submission-system/program-clinical-submission/Header.tsx
@@ -20,6 +20,7 @@ import { useClinicalSubmissionQuery } from '.';
 import useCommonToasters from 'components/useCommonToasters';
 import { useRouter } from 'next/router';
 import { DCC_PATH } from 'global/constants/pages';
+import { useToaster } from 'global/hooks/toaster';
 
 export default ({
   programShortName,
@@ -45,6 +46,8 @@ export default ({
   const { refetch: refetchClinicalSubmission } = useClinicalSubmissionQuery(programShortName);
   const commonToaster = useCommonToasters();
   const router = useRouter();
+  const toaster = useToaster();
+  const { data } = useClinicalSubmissionQuery(programShortName);
 
   const [reopenSubmission] = useMutation<
     ClinicalSubmissionQueryData,
@@ -102,6 +105,14 @@ export default ({
       try {
         await approveClinicalSubmission();
         router.push(DCC_PATH);
+        toaster.addToast({
+          variant: 'SUCCESS',
+          interactionType: 'CLOSE',
+          title: 'Clinical Data is successfully approved',
+          content: `${
+            data.program.name
+          } clinical data will be placed in a queue for the next release.`,
+        });
       } catch (err) {
         await refetchClinicalSubmission();
         commonToaster.unknownErrorWithReloadMessage();

--- a/components/pages/submission-system/program-clinical-submission/Header.tsx
+++ b/components/pages/submission-system/program-clinical-submission/Header.tsx
@@ -16,7 +16,7 @@ import { ModalPortal } from 'components/ApplicationRoot';
 import Modal from 'uikit/Modal';
 import DnaLoader from 'uikit/DnaLoader';
 import { sleep } from 'global/utils/common';
-import { useClinicalSubmissionQuery } from '.';
+import { useClinicalSubmissionQuery, placeholderClinicalSubmissionQueryData } from '.';
 import useCommonToasters from 'components/useCommonToasters';
 import { useRouter } from 'next/router';
 import { DCC_PATH } from 'global/constants/pages';
@@ -47,7 +47,9 @@ export default ({
   const commonToaster = useCommonToasters();
   const router = useRouter();
   const toaster = useToaster();
-  const { data } = useClinicalSubmissionQuery(programShortName);
+  const { data, updateQuery: updateClinicalSubmissionQuery } = useClinicalSubmissionQuery(
+    programShortName,
+  );
 
   const [reopenSubmission] = useMutation<
     ClinicalSubmissionQueryData,
@@ -113,6 +115,10 @@ export default ({
             data.program.name
           } clinical data will be placed in a queue for the next release.`,
         });
+        updateClinicalSubmissionQuery(previous => ({
+          ...previous,
+          clinicalSubmissions: placeholderClinicalSubmissionQueryData.clinicalSubmissions,
+        }));
       } catch (err) {
         await refetchClinicalSubmission();
         commonToaster.unknownErrorWithReloadMessage();

--- a/components/pages/submission-system/program-clinical-submission/Header.tsx
+++ b/components/pages/submission-system/program-clinical-submission/Header.tsx
@@ -151,7 +151,7 @@ export default ({
             >
               Submit Clinical Data
             </div>
-            {!showProgress && (
+            {showProgress && (
               <Progress>
                 <Progress.Item text="Upload" state={progressStates.upload} />
                 <Progress.Item text="Validate" state={progressStates.validate} />

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -39,6 +39,7 @@ import map from 'lodash/map';
 import memoize from 'lodash/memoize';
 import uniq from 'lodash/uniq';
 import useCommonToasters from 'components/useCommonToasters';
+import { useClinicalSubmissionQuery } from '.';
 
 const gqlClinicalEntityToClinicalSubmissionEntityFile = (
   submissionState: ClinicalSubmissionQueryData['clinicalSubmissions']['state'],
@@ -96,29 +97,12 @@ export default () => {
   const toaster = useToaster();
   const commonToaster = useCommonToasters();
 
-  const placeHolderResponse: ClinicalSubmissionQueryData = {
-    clinicalSubmissions: {
-      version: '',
-      clinicalEntities: [],
-      fileErrors: [],
-      id: '',
-      state: 'OPEN',
-      updatedAt: '',
-      updatedBy: '',
-      __typename: 'ClinicalSubmissionData',
-    },
-  };
-
   const {
-    data = placeHolderResponse,
+    data,
     loading: loadingClinicalSubmission,
     updateQuery: updateClinicalSubmissionQuery,
     refetch,
-  } = useQuery<ClinicalSubmissionQueryData>(CLINICAL_SUBMISSION_QUERY, {
-    variables: {
-      programShortName,
-    },
-  });
+  } = useClinicalSubmissionQuery(programShortName);
 
   const fileNavigatorFiles = map(
     orderBy(data.clinicalSubmissions.clinicalEntities, e => e.clinicalType),

--- a/components/pages/submission-system/program-clinical-submission/gql/CLINICAL_SUBMISSION_QUERY.gql
+++ b/components/pages/submission-system/program-clinical-submission/gql/CLINICAL_SUBMISSION_QUERY.gql
@@ -1,6 +1,9 @@
 #import "./CLINICAL_SUBMISSION_FRAGMENT.gql"
 
 query CLINICAL_SUBMISSIONS_QUERY($programShortName: String!) {
+  program(shortName: $programShortName) {
+    name
+  }
   clinicalSubmissions(programShortName: $programShortName) {
     ...ClinicalSubmissionFragment
   }

--- a/components/pages/submission-system/program-clinical-submission/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/index.tsx
@@ -19,7 +19,7 @@ export const placeholderClinicalSubmissionQueryData: ClinicalSubmissionQueryData
     clinicalEntities: [],
     fileErrors: [],
     id: '',
-    state: 'OPEN',
+    state: null,
     updatedAt: '',
     updatedBy: '',
     __typename: 'ClinicalSubmissionData',

--- a/components/pages/submission-system/program-clinical-submission/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/index.tsx
@@ -10,27 +10,30 @@ import { useTheme } from 'uikit/ThemeProvider';
 import Header from './Header';
 import PageContent from './PageContent';
 
-export const useClinicalSubmissionQuery = (programShortName: string) => {
-  const placeHolderResponse: ClinicalSubmissionQueryData = {
-    clinicalSubmissions: {
-      version: '',
-      clinicalEntities: [],
-      fileErrors: [],
-      id: '',
-      state: 'OPEN',
-      updatedAt: '',
-      updatedBy: '',
-      __typename: 'ClinicalSubmissionData',
-    },
-  };
+export const placeholderClinicalSubmissionQueryData: ClinicalSubmissionQueryData = {
+  program: {
+    name: '',
+  },
+  clinicalSubmissions: {
+    version: '',
+    clinicalEntities: [],
+    fileErrors: [],
+    id: '',
+    state: 'OPEN',
+    updatedAt: '',
+    updatedBy: '',
+    __typename: 'ClinicalSubmissionData',
+  },
+};
 
+export const useClinicalSubmissionQuery = (programShortName: string) => {
   const hook = useQuery<ClinicalSubmissionQueryData>(CLINICAL_SUBMISSION_QUERY, {
     variables: {
       programShortName,
     },
   });
 
-  return { ...hook, data: hook.data || placeHolderResponse };
+  return { ...hook, data: hook.data || placeholderClinicalSubmissionQueryData };
 };
 
 export default function ProgramClinicalSubmission() {

--- a/components/pages/submission-system/program-clinical-submission/types.tsx
+++ b/components/pages/submission-system/program-clinical-submission/types.tsx
@@ -92,4 +92,7 @@ export type SignOffSubmissionMutationVariables = {
 
 export type ClinicalSubmissionQueryData = {
   clinicalSubmissions: GqlClinicalSubmissionData;
+  program: {
+    name: string;
+  };
 };


### PR DESCRIPTION
**Description of changes**

- adds a toast for dcc approval success
- refactors the `PageContent` component to use the `useClinicalSubmissionQuery` hook
- fixes the progress bar not showing (I derped earlier)
- fixes some content 
- updates clinical submission query on client side after dcc approves. (because the gql mutation does not return a `ClinicalSubmissionData`, cache must be updated manually)

**Type of Change**

- [x] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- [x] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
