### PR TITLE
remove whitespace in env vars

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -15,10 +15,10 @@ EGO_API_ROOT=https://....
 EGO_CLIENT_ID=ego-application
 
 # Testing
-BROWSERSTACK_ACCESS_KEY = ''
-BROWSERSTACK_USER = ''
-BROWSERSTACK_API_ROOT = https://api.browserstack.com/automate
-BROWSERSTACK_SELENIUM_HOST = hub-cloud.browserstack.com
-BROWSERSTACK_PROJECT_NAME = a_project_name # https://www.browserstack.com/question/640 (valid characters)
-TEST_GOOGLE_USER = # user email
-TEST_GOOGLE_PASS = # user pass
+BROWSERSTACK_ACCESS_KEY= ''
+BROWSERSTACK_USER= ''
+BROWSERSTACK_API_ROOT= https://api.browserstack.com/automate
+BROWSERSTACK_SELENIUM_HOST= hub-cloud.browserstack.com
+BROWSERSTACK_PROJECT_NAME= a_project_name # https://www.browserstack.com/question/640 (valid characters)
+TEST_GOOGLE_USER= # user email
+TEST_GOOGLE_PASS= # user pass


### PR DESCRIPTION
**Description of changes**

docker yells if there is white space in env vars before the '='

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
