### PR TITLE
🐛 default error table row index should be 1-index

### DIFF
--- a/components/pages/submission-system/ErrorNotification.tsx
+++ b/components/pages/submission-system/ErrorNotification.tsx
@@ -13,6 +13,7 @@ export const defaultColumns = [
     accessor: 'row',
     Header: 'Row #',
     maxWidth: 70,
+    Cell: ({ original }) => <>{Number(original.row) + 1}</>,
   },
   {
     accessor: 'donorId',
@@ -47,7 +48,7 @@ export default <Error extends { [k: string]: any }>({
   subtitle: string;
   columnConfig: Array<
     TableColumnConfig<Error> & {
-      accessor: string;
+      accessor: keyof Error;
     }
   >;
   errors: Array<Error>;

--- a/components/pages/submission-system/ErrorNotification.tsx
+++ b/components/pages/submission-system/ErrorNotification.tsx
@@ -7,13 +7,14 @@ import { exportToTsv } from 'global/utils/common';
 import Icon from 'uikit/Icon';
 import { instructionBoxButtonIconStyle, instructionBoxButtonContentStyle } from './common';
 import union from 'lodash/union';
+import { toDisplayRowIndex } from 'global/utils/clinicalUtils';
 
 export const defaultColumns = [
   {
     accessor: 'row',
     Header: 'Row #',
     maxWidth: 70,
-    Cell: ({ original }) => <>{Number(original.row) + 1}</>,
+    Cell: ({ original }) => <>{toDisplayRowIndex(original.row)}</>,
   },
   {
     accessor: 'donorId',

--- a/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
+++ b/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
@@ -13,6 +13,7 @@ import { CSSProperties, createRef } from 'react';
 import { useTheme } from 'uikit/ThemeProvider';
 import useAuthContext from 'global/hooks/useAuthContext';
 import { isDccMember } from 'global/utils/egoJwt';
+import { toDisplayRowIndex } from 'global/utils/clinicalUtils';
 
 const StarIcon = DataTableStarIcon;
 
@@ -229,7 +230,7 @@ export default ({
               : css``
           }
         >
-          {Number(original.row) + 1}
+          {toDisplayRowIndex(original.row)}
         </CellContentCenter>
       ),
       Header: '#',

--- a/global/utils/clinicalUtils.ts
+++ b/global/utils/clinicalUtils.ts
@@ -1,0 +1,1 @@
+export const toDisplayRowIndex = (index: number | string) => Number(index) + 1;


### PR DESCRIPTION
**Description of changes**

Just making sure error tables also display rows with 1-index

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
