### PR TITLE
Feat/ci gql test

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -5,7 +5,7 @@ def commit = "UNKNOWN"
 pipeline {
     agent {
         kubernetes {
-            label 'gateway-executor'
+            label 'platform-ui-executor'
             yaml """
 apiVersion: v1
 kind: Pod

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -52,6 +52,9 @@ spec:
                     sh "npm run build"
                     sh "npm run test"
                 }
+                container('node') {
+                    sh "GATEWAY_API_ROOT=https://argo-gateway.dev.argo.cancercollaboratory.org/ npm run test-gql-validation"
+                }
             }
         }
 

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -14,11 +14,6 @@ spec:
   - name: node
     image: node:12.6.0
     tty: true
-  - name: helm
-    image: alpine/helm:2.12.3
-    tty: true
-    command:
-    - cat
   - name: docker
     image: docker:18-git
     tty: true


### PR DESCRIPTION
**Description of changes**

- adds graphql schema validation against DEV as a step of CI test before CD (i.e for every PR)
  + Why? I thought about what Jon said and realized it is probably valuable to know the API compliance status for the PR before it is merged to `develop`.
  + Why not against QA? Everything that goes to QA must go through `dev`, so it would be redundant.
- removes a container definition that wasn't used in `Jenkinsfile`
- labels the Jenkins executor properly (it was overlapping with gateway before, probably because of copy-paste)