### PR TITLE
🐛 defaults svg.css to empty string

### DIFF
--- a/uikit/Icon/index.tsx
+++ b/uikit/Icon/index.tsx
@@ -32,7 +32,7 @@ const Icon: React.ComponentType<
   return (
     <svg
       css={css`
-        ${svg.css};
+        ${svg.css || ''}
         height: ${height};
         width: ${width};
       `}


### PR DESCRIPTION
this should fix the escape css string escape problem for the icon component