### PR TITLE
💄 tag style overrides

### DIFF
--- a/uikit/Tag/index.tsx
+++ b/uikit/Tag/index.tsx
@@ -31,6 +31,7 @@ const Tag = styled<'div', { variant?: keyof typeof TAG_VARIANTS }>('div')`
       [TAG_VARIANTS.UPDATE]: theme.colors.accent3_dark,
     }[variant])};
   color: white;
+  ${({ style }) => ({ ...style })}
 `;
 
 export default Tag;

--- a/uikit/Tag/stories.tsx
+++ b/uikit/Tag/stories.tsx
@@ -11,6 +11,7 @@ const TagStories = storiesOf(`${__dirname}`, module)
       Tag label&nbsp;&nbsp;
       <Icon width="8px" height="8px" name="times" fill="#fff" />
     </Tag>
-  ));
+  ))
+  .add('Tag with override style', () => <Tag style={{ backgroundColor: 'red' }}>Tag label</Tag>);
 
 export default TagStories;


### PR DESCRIPTION
**Description of changes**
allow tag styling overrides

but why? 
as the uses cases of uikit are expanding the variant constants for components are too constricting

example: 
uikit tag component in doc site needs a different background.
can't just be a nested div because there is a specific border radius color
current variants of ERROR, WARNING etc don't make semantic sense even if the color was correct



<!-- Please add a brief description of the changes here. -->

**Type of Change**

- [ ] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
