### PR TITLE
🐛 refactor to remove illegal char

### DIFF
--- a/uikit/Link/index.tsx
+++ b/uikit/Link/index.tsx
@@ -19,11 +19,8 @@ const StyledLink = styled<'a', HyperLinkProps>('a')`
   color: ${({ theme, invert }) => (invert ? theme.colors.white : theme.colors.accent2_dark)};
   text-decoration: ${({ underline }) => (underline ? 'underline' : 'none')};
   font-weight: ${({ bold }) => (bold ? 'bold' : 'inherit')};
-  ${({ uppercase }) =>
-    uppercase &&
-    css`
-      text-transform: uppercase;
-    `}
+  text-transform: ${({ uppercase }) => (uppercase ? 'uppercase' : 'default')};
+
   :hover {
     color: ${({ theme }) => theme.colors.accent2_1};
   }


### PR DESCRIPTION
**Description of changes**

change format of css block so string interpolation doesn't contain illegal chars
fixes a lot of dev console warnings in external projects using uikit

emotion only throws the error when NODE_ENV != 'production' but it's a lot of effort to change this in some frameworks that have opinionated webpack commands that are hard to override eg. docusaurus


**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
