### PR TITLE
🐛 1067 - prevent enabled save when user modal data is not changed

### DIFF
--- a/components/pages/submission-system/modals/editUser/index.tsx
+++ b/components/pages/submission-system/modals/editUser/index.tsx
@@ -45,7 +45,11 @@ const EditUserModal = ({
     >
       <UserSection
         user={form}
-        onChange={(key, val) => setData({ key, val })}
+        onChange={(key, val) => {
+          if (form[key] !== val) {
+            return setData({ key, val });
+          }
+        }}
         validateField={key => validateField({ key })}
         errors={validationErrors}
         disabledFields={['email', 'firstName', 'lastName']}

--- a/components/pages/submission-system/modals/editUser/index.tsx
+++ b/components/pages/submission-system/modals/editUser/index.tsx
@@ -45,11 +45,7 @@ const EditUserModal = ({
     >
       <UserSection
         user={form}
-        onChange={(key, val) => {
-          if (form[key] !== val) {
-            return setData({ key, val });
-          }
-        }}
+        onChange={(key, val) => setData({ key, val })}
         validateField={key => validateField({ key })}
         errors={validationErrors}
         disabledFields={['email', 'firstName', 'lastName']}

--- a/global/hooks/useFormHook.tsx
+++ b/global/hooks/useFormHook.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import isArray from 'lodash/isArray';
 import yup from 'global/utils/validations';
 
@@ -34,15 +35,13 @@ function useFormHook<T extends DefaultDataShape>({
   const [form, setForm] = useState<{ errors: typeof initErrors; data: typeof initialFields }>(
     initialState,
   );
-  const [touched, setTouched] = useState(false);
+
   const { errors, data } = form;
 
   const hasErrors = Object.values(errors).some(x => x);
 
   // set form data
   const setData = ({ key, val }: FormData<T>) => {
-    if (!touched) setTouched(true);
-
     setForm({
       ...form,
       data: { ...data, [key]: val },
@@ -113,7 +112,7 @@ function useFormHook<T extends DefaultDataShape>({
     setData,
     validateField,
     validateForm,
-    touched,
+    touched: !isEqual(initialFields, form.data),
     hasErrors,
     reset,
   };


### PR DESCRIPTION
**Description of changes**

On the EditUser modal, save button will remain disabled unless user form data is changed.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
