### PR TITLE
🐳 builds and runs container with non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:12.13.1
 
-ENV UID=9999
-ENV GID=9999
-RUN groupmod -g $GID node 
-RUN usermod -u $UID -g $GID node
+ENV APP_UID=9999
+ENV APP_GID=9999
+RUN groupmod -g $APP_GID node 
+RUN usermod -u $APP_UID -g $APP_GID node
 RUN mkdir -p /appDir
 RUN chown -R node /appDir
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM node:12.13.1
 
-ENV APP_UID=9999
-ENV APP_GID=9999
-RUN groupmod -g $APP_GID node 
-RUN usermod -u $APP_UID -g $APP_GID node
 RUN mkdir -p /appDir
 RUN chown -R node /appDir
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.13.1
+FROM node:12.13.1-alpine
 
 RUN mkdir -p /appDir
 RUN chown -R node /appDir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM node:alpine
-WORKDIR /usr/src/app
+FROM node:12.13.1
 
-COPY ./package.json ./package-lock.json ./
-RUN npm ci
+ENV UID=9999
+ENV GID=9999
+RUN groupmod -g $GID node 
+RUN usermod -u $UID -g $GID node
+RUN mkdir -p /appDir
+RUN chown -R node /appDir
+USER node
+WORKDIR /appDir
+
 COPY . .
+RUN npm ci
 RUN npx next build
 
 EXPOSE 8080


### PR DESCRIPTION
**Description of changes**

Updates Dockerfile to use non-root user

- uses the pre-configured `node` user provided by node base image, which has permissions set up to run `npm ci` (see doc: https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user)