### PR TITLE
Make clinical toast behave like registration toast

### DIFF
--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -30,7 +30,7 @@ import SubmissionSummaryTable from './SubmissionSummaryTable';
 import useUserConfirmationModalState from './useUserConfirmationModalState';
 import Typography from 'uikit/Typography';
 import { sleep } from 'global/utils/common';
-import { useRouter } from 'next/router';
+import Router from 'next/router';
 import { PROGRAM_DASHBOARD_PATH, PROGRAM_SHORT_NAME_PATH } from 'global/constants/pages';
 import orderBy from 'lodash/orderBy';
 import head from 'lodash/head';
@@ -91,7 +91,6 @@ const gqlClinicalEntityToClinicalSubmissionEntityFile = (
 export default () => {
   const { shortName: programShortName } = usePageQuery<{ shortName: string }>();
   const { setLoading: setPageLoaderShown } = useGlobalLoadingState();
-  const router = useRouter();
   const [currentFileList, setCurrentFileList] = React.useState<FileList | null>(null);
   const {
     isModalShown: signOffModalShown,
@@ -293,14 +292,16 @@ export default () => {
         });
 
         if (newData.clinicalSubmissions.state === null) {
+          Router.push(
+            PROGRAM_DASHBOARD_PATH,
+            PROGRAM_DASHBOARD_PATH.replace(PROGRAM_SHORT_NAME_PATH, programShortName),
+          );
           toaster.addToast({
             variant: 'SUCCESS',
             interactionType: 'CLOSE',
             title: 'Successful Clinical Submission!',
             content: 'Your clinical data has been submitted.',
           });
-
-          router.push(PROGRAM_DASHBOARD_PATH.replace(PROGRAM_SHORT_NAME_PATH, programShortName));
         } else {
           setPageLoaderShown(false);
         }


### PR DESCRIPTION
**Description of changes**

- Make clinical toast behave like registration toast
- Previously toast would get wiped away almost instantly ([see here ](https://drive.google.com/file/d/1R0Vi_Jl8KYbgOEaCdxJ88tmE60Lw_DhT/view?usp=sharing))
- Now it mimics the sample registration behaviour ([see here](https://drive.google.com/file/d/1gkrOOUQczC71vDPpv5xPd0IzhT-0XY4e/view?usp=sharing))


**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
