### PR TITLE
Add sleep() to loading modal to prevent flashes

### DIFF
--- a/global/hooks/useProgramCheckEffect.tsx
+++ b/global/hooks/useProgramCheckEffect.tsx
@@ -1,15 +1,14 @@
 import { usePageQuery } from 'global/hooks/usePageContext';
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
 import { ERROR_STATUS_KEY } from 'pages/_error';
 import PROGRAM_SHORTNAME from './PROGRAM_SHORTNAME.gql';
 import { useGlobalLoadingState } from 'components/ApplicationRoot';
+import { sleep } from 'global/utils/common';
 
 export const useProgramCheckEffect = () => {
   const { shortName } = usePageQuery<{ shortName: string }>();
-  const [programNotExist, setProgramNotExist] = useState(false);
-
-  const { loading, data: { program = undefined } = {} } = useQuery<{
+  const { loading: loadingQuery, data: { program = undefined } = {} } = useQuery<{
     program: { name: string; shortName: string };
   }>(PROGRAM_SHORTNAME, {
     variables: {
@@ -17,16 +16,26 @@ export const useProgramCheckEffect = () => {
     },
   });
 
-  const { setLoading } = useGlobalLoadingState();
-
+  const { setLoading, isLoading } = useGlobalLoadingState();
   useEffect(() => {
-    setLoading(loading);
-    setProgramNotExist(loading ? false : !program);
-  }, [program, loading]);
+    // Generate a new loading modal ONLY if the program's existence is unknown
+    if (!program && !isLoading) {
+      setLoading(true);
+    }
+    // Check if the query to check for program existence has finished
+    if (!loadingQuery) {
+      // Now that loading is finished, the program must not exist. Break and send to 404.
+      if (!program) {
+        const err = new Error('Program not found') as Error & { statusCode?: number };
+        err[ERROR_STATUS_KEY] = 404;
+        throw err;
+      }
 
-  if (programNotExist) {
-    const err = new Error('Program not found') as Error & { statusCode?: number };
-    err[ERROR_STATUS_KEY] = 404;
-    throw err;
-  }
+      // Otherwise, the query result is back and the program does exist.
+      // Wait for a small buffer time so the loading modal animation has enough time.
+      else if (isLoading) {
+        sleep(1200).then(() => setLoading(false));
+      }
+    }
+  }, [program, loadingQuery]);
 };

--- a/global/hooks/useProgramCheckEffect.tsx
+++ b/global/hooks/useProgramCheckEffect.tsx
@@ -16,25 +16,18 @@ export const useProgramCheckEffect = () => {
     },
   });
 
-  const { setLoading, isLoading } = useGlobalLoadingState();
+  const { setLoading: setLoaderShown, isLoading: isLoaderShown } = useGlobalLoadingState();
   useEffect(() => {
-    // Generate a new loading modal ONLY if the program's existence is unknown
-    if (!program && !isLoading) {
-      setLoading(true);
+    if (!program && !isLoaderShown) {
+      setLoaderShown(true);
     }
-    // Check if the query to check for program existence has finished
     if (!loadingQuery) {
-      // Now that loading is finished, the program must not exist. Break and send to 404.
       if (!program) {
         const err = new Error('Program not found') as Error & { statusCode?: number };
         err[ERROR_STATUS_KEY] = 404;
         throw err;
-      }
-
-      // Otherwise, the query result is back and the program does exist.
-      // Wait for a small buffer time so the loading modal animation has enough time.
-      else if (isLoading) {
-        sleep(1200).then(() => setLoading(false));
+      } else if (isLoaderShown) {
+        sleep(1200).then(() => setLoaderShown(false));
       }
     }
   }, [program, loadingQuery]);


### PR DESCRIPTION
**Description of changes**

- Whenever you would click on a program's page, while the program's existence was being checked, a loading modal was rendered
- In the case where the existence was confirmed to be true, the modal was wiped away so quickly that it looked like a strange flash on the page
- Added a 1200ms sleep before the modal removal so the loading animation is actually obvious before it gets wiped away


**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
