### PR TITLE
Make upload icon white if disabled

### DIFF
--- a/components/pages/submission-system/program-clinical-submission/Instruction/index.tsx
+++ b/components/pages/submission-system/program-clinical-submission/Instruction/index.tsx
@@ -81,7 +81,7 @@ export default ({
             <span css={instructionBoxButtonContentStyle}>
               <Icon
                 name="upload"
-                fill="accent2_dark"
+                fill={uploadEnabled ? 'accent2_dark' : 'white'}
                 height="12px"
                 css={instructionBoxButtonIconStyle}
               />


### PR DESCRIPTION
**Description of changes**

If uploading is disabled, the upload icon should be white.

**Type of Change**

- [ ] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
