### PR TITLE
Make newlines in error messages show up as <br>

### DIFF
--- a/components/pages/submission-system/ErrorNotification.tsx
+++ b/components/pages/submission-system/ErrorNotification.tsx
@@ -135,7 +135,7 @@ export default <Error extends { [k: string]: any }>({
               columns={columnConfig.map(col => ({
                 ...col,
                 style: {
-                  whiteSpace: 'unset',
+                  whiteSpace: 'pre-line',
                   ...(col.style || {}),
                 },
               }))}


### PR DESCRIPTION
**Description of changes**

Detailed error messages may have newline characters
Use set whitespace attr to `pre-line` so they show up

**Type of Change**

- [ ] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
