### PR TITLE
Don't show links for collaborators

### DIFF
--- a/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
@@ -39,26 +39,26 @@ export default function ProgramWorkplaceStatus() {
   };
   return (
     <DashboardCard cardHeight="170px">
-      <Typography variant="default" component="span">
-        Program Workplace Status
-      </Typography>
+     <Typography variant="default" component="span">
+          Program Workplace Status
+        </Typography>
 
-      <div
-        css={css`
-          height: 50px;
-          display: flex;
-          flex-direction: row;
-          padding-top: 10px;
-        `}
-      >
         <div
           css={css`
-            margin-top: 7px;
-            width: 175px;
             height: 50px;
+            display: flex;
+            flex-direction: row;
+            padding-top: 10px;
           `}
         >
-          <LinkWrapper
+          <div
+            css={css`
+              margin-top: 7px;
+              width: 175px;
+              height: 50px;
+            `}
+          >
+            <LinkWrapper
             access={currentUserStatus}
             wrapper={(children: ReactNode) => (
               <Link
@@ -74,30 +74,30 @@ export default function ProgramWorkplaceStatus() {
           >
             <Typography variant="label">Sample Registration</Typography>
           </LinkWrapper>
+          </div>
+          <div
+            css={css`
+              height: 50px;
+            `}
+          >
+            <SampleRegistrationProgressBar programShortName={programShortName} />
+          </div>
         </div>
         <div
           css={css`
             height: 50px;
+            display: flex;
+            flex-direction: row;
           `}
         >
-          <SampleRegistrationProgressBar programShortName={programShortName} />
-        </div>
-      </div>
-      <div
-        css={css`
-          height: 50px;
-          display: flex;
-          flex-direction: row;
-        `}
-      >
-        <div
-          css={css`
-            margin-top: 7px;
-            width: 175px;
-            height: 50px;
-          `}
-        >
-          <LinkWrapper
+          <div
+            css={css`
+              margin-top: 7px;
+              width: 175px;
+              height: 50px;
+            `}
+          >
+            <LinkWrapper
             access={currentUserStatus}
             wrapper={(children: ReactNode) => (
               <Link
@@ -113,15 +113,15 @@ export default function ProgramWorkplaceStatus() {
           >
             <Typography variant="label">Clinical Submission</Typography>
           </LinkWrapper>
+          </div>
+          <div
+            css={css`
+              height: 50px;
+            `}
+          >
+            <ClinicalSubmissionProgressBar programShortName={programShortName} />
+          </div>
         </div>
-        <div
-          css={css`
-            height: 50px;
-          `}
-        >
-          <ClinicalSubmissionProgressBar programShortName={programShortName} />
-        </div>
-      </div>
     </DashboardCard>
   );
 }

--- a/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
@@ -17,12 +17,12 @@ import { isCollaborator } from 'global/utils/egoJwt';
 import { ReactNode } from 'react';
 import useAuthContext from 'global/hooks/useAuthContext';
 
-type accessStatus = {
+type AccessStatus = {
   jwt: string;
   programId: string;
 };
 const LinkWrapper: React.ComponentType<{
-  access: accessStatus;
+  access: AccessStatus;
   wrapper: Function;
   children: ReactNode;
 }> = ({ wrapper, access, children }) => {
@@ -33,32 +33,32 @@ const LinkWrapper: React.ComponentType<{
 export default function ProgramWorkplaceStatus() {
   const { shortName: programShortName } = usePageQuery<{ shortName: string }>();
   const { token } = useAuthContext();
-  const currentUserStatus: accessStatus = {
+  const currentUserStatus: AccessStatus = {
     jwt: token,
     programId: programShortName,
   };
   return (
     <DashboardCard cardHeight="170px">
-     <Typography variant="default" component="span">
-          Program Workplace Status
-        </Typography>
+      <Typography variant="default" component="span">
+        Program Workplace Status
+      </Typography>
 
+      <div
+        css={css`
+          height: 50px;
+          display: flex;
+          flex-direction: row;
+          padding-top: 10px;
+        `}
+      >
         <div
           css={css`
+            margin-top: 7px;
+            width: 175px;
             height: 50px;
-            display: flex;
-            flex-direction: row;
-            padding-top: 10px;
           `}
         >
-          <div
-            css={css`
-              margin-top: 7px;
-              width: 175px;
-              height: 50px;
-            `}
-          >
-            <LinkWrapper
+          <LinkWrapper
             access={currentUserStatus}
             wrapper={(children: ReactNode) => (
               <Link
@@ -74,30 +74,30 @@ export default function ProgramWorkplaceStatus() {
           >
             <Typography variant="label">Sample Registration</Typography>
           </LinkWrapper>
-          </div>
-          <div
-            css={css`
-              height: 50px;
-            `}
-          >
-            <SampleRegistrationProgressBar programShortName={programShortName} />
-          </div>
         </div>
         <div
           css={css`
             height: 50px;
-            display: flex;
-            flex-direction: row;
           `}
         >
-          <div
-            css={css`
-              margin-top: 7px;
-              width: 175px;
-              height: 50px;
-            `}
-          >
-            <LinkWrapper
+          <SampleRegistrationProgressBar programShortName={programShortName} />
+        </div>
+      </div>
+      <div
+        css={css`
+          height: 50px;
+          display: flex;
+          flex-direction: row;
+        `}
+      >
+        <div
+          css={css`
+            margin-top: 7px;
+            width: 175px;
+            height: 50px;
+          `}
+        >
+          <LinkWrapper
             access={currentUserStatus}
             wrapper={(children: ReactNode) => (
               <Link
@@ -113,15 +113,15 @@ export default function ProgramWorkplaceStatus() {
           >
             <Typography variant="label">Clinical Submission</Typography>
           </LinkWrapper>
-          </div>
-          <div
-            css={css`
-              height: 50px;
-            `}
-          >
-            <ClinicalSubmissionProgressBar programShortName={programShortName} />
-          </div>
         </div>
+        <div
+          css={css`
+            height: 50px;
+          `}
+        >
+          <ClinicalSubmissionProgressBar programShortName={programShortName} />
+        </div>
+      </div>
     </DashboardCard>
   );
 }

--- a/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
@@ -13,9 +13,30 @@ import {
   PROGRAM_CLINICAL_SUBMISSION_PATH,
 } from 'global/constants/pages';
 import { DashboardCard } from '../common';
+import { isCollaborator } from 'global/utils/egoJwt';
+import { ReactNode } from 'react';
+import useAuthContext from 'global/hooks/useAuthContext';
+
+type accessStatus = {
+  jwt: string;
+  programId: string;
+};
+const LinkWrapper: React.ComponentType<{
+  access: accessStatus;
+  wrapper: Function;
+  children: ReactNode;
+}> = ({ wrapper, access, children }) => {
+  const canViewLinks = !isCollaborator({ egoJwt: access.jwt, programId: access.programId });
+  return canViewLinks ? wrapper(children) : children;
+};
 
 export default function ProgramWorkplaceStatus() {
   const { shortName: programShortName } = usePageQuery<{ shortName: string }>();
+  const { token } = useAuthContext();
+  const currentUserStatus: accessStatus = {
+    jwt: token,
+    programId: programShortName,
+  };
   return (
     <DashboardCard cardHeight="170px">
      <Typography variant="default" component="span">
@@ -37,17 +58,22 @@ export default function ProgramWorkplaceStatus() {
               height: 50px;
             `}
           >
-            <Link
-              href={PROGRAM_SAMPLE_REGISTRATION_PATH}
-              as={PROGRAM_SAMPLE_REGISTRATION_PATH.replace(
-                PROGRAM_SHORT_NAME_PATH,
-                programShortName as string,
-              )}
-            >
-              <Hyperlink>
-                <Typography variant="label">Sample Registration</Typography>
-              </Hyperlink>
-            </Link>
+            <LinkWrapper
+            access={currentUserStatus}
+            wrapper={(children: ReactNode) => (
+              <Link
+                href={PROGRAM_SAMPLE_REGISTRATION_PATH}
+                as={PROGRAM_SAMPLE_REGISTRATION_PATH.replace(
+                  PROGRAM_SHORT_NAME_PATH,
+                  programShortName as string,
+                )}
+              >
+                <Hyperlink>{children}</Hyperlink>
+              </Link>
+            )}
+          >
+            <Typography variant="label">Sample Registration</Typography>
+          </LinkWrapper>
           </div>
           <div
             css={css`
@@ -71,17 +97,22 @@ export default function ProgramWorkplaceStatus() {
               height: 50px;
             `}
           >
-            <Link
-              href={PROGRAM_CLINICAL_SUBMISSION_PATH}
-              as={PROGRAM_CLINICAL_SUBMISSION_PATH.replace(
-                PROGRAM_SHORT_NAME_PATH,
-                programShortName as string,
-              )}
-            >
-              <Hyperlink>
-                <Typography variant="label">Clinical Submission</Typography>
-              </Hyperlink>
-            </Link>
+            <LinkWrapper
+            access={currentUserStatus}
+            wrapper={(children: ReactNode) => (
+              <Link
+                href={PROGRAM_CLINICAL_SUBMISSION_PATH}
+                as={PROGRAM_CLINICAL_SUBMISSION_PATH.replace(
+                  PROGRAM_SHORT_NAME_PATH,
+                  programShortName as string,
+                )}
+              >
+                <Hyperlink>{children}</Hyperlink>
+              </Link>
+            )}
+          >
+            <Typography variant="label">Clinical Submission</Typography>
+          </LinkWrapper>
           </div>
           <div
             css={css`

--- a/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
@@ -5,8 +5,8 @@ import { Row, Col } from 'react-grid-system';
 import ClinicalSubmissionProgressBar from '../../ClinicalSubmissionProgressBar';
 import { usePageQuery } from 'global/hooks/usePageContext';
 import SampleRegistrationProgressBar from '../../SampleRegistrationProgressBar';
-import Hyperlink from 'uikit/Link';
-import Link from 'next/link';
+import Hyperlink, { HyperLinkProps } from 'uikit/Link';
+import Link, { LinkProps } from 'next/link';
 import {
   PROGRAM_SAMPLE_REGISTRATION_PATH,
   PROGRAM_SHORT_NAME_PATH,
@@ -17,26 +17,24 @@ import { isCollaborator } from 'global/utils/egoJwt';
 import { ReactNode } from 'react';
 import useAuthContext from 'global/hooks/useAuthContext';
 
-type AccessStatus = {
-  jwt: string;
-  programId: string;
-};
-const LinkWrapper: React.ComponentType<{
-  access: AccessStatus;
-  wrapper: Function;
-  children: ReactNode;
-}> = ({ wrapper, access, children }) => {
-  const canViewLinks = !isCollaborator({ egoJwt: access.jwt, programId: access.programId });
-  return canViewLinks ? wrapper(children) : children;
+const ConditionalLink: React.ComponentType<{
+  showAsLink: boolean;
+  link: LinkProps;
+  hyperlink?: HyperLinkProps;
+}> = ({ showAsLink, link, hyperlink, children }) => {
+  return showAsLink ? (
+    <Link {...link}>
+      <Hyperlink {...hyperlink}>{children}</Hyperlink>
+    </Link>
+  ) : (
+    <>{children}</>
+  );
 };
 
 export default function ProgramWorkplaceStatus() {
   const { shortName: programShortName } = usePageQuery<{ shortName: string }>();
   const { token } = useAuthContext();
-  const currentUserStatus: AccessStatus = {
-    jwt: token,
-    programId: programShortName,
-  };
+  const canViewLinks = !isCollaborator({ egoJwt: token, programId: programShortName });
   return (
     <DashboardCard cardHeight="170px">
       <Typography variant="default" component="span">
@@ -58,22 +56,18 @@ export default function ProgramWorkplaceStatus() {
             height: 50px;
           `}
         >
-          <LinkWrapper
-            access={currentUserStatus}
-            wrapper={(children: ReactNode) => (
-              <Link
-                href={PROGRAM_SAMPLE_REGISTRATION_PATH}
-                as={PROGRAM_SAMPLE_REGISTRATION_PATH.replace(
-                  PROGRAM_SHORT_NAME_PATH,
-                  programShortName as string,
-                )}
-              >
-                <Hyperlink>{children}</Hyperlink>
-              </Link>
-            )}
+          <ConditionalLink
+            showAsLink={canViewLinks}
+            link={{
+              href: PROGRAM_SAMPLE_REGISTRATION_PATH,
+              as: PROGRAM_SAMPLE_REGISTRATION_PATH.replace(
+                PROGRAM_SHORT_NAME_PATH,
+                programShortName as string,
+              ),
+            }}
           >
             <Typography variant="label">Sample Registration</Typography>
-          </LinkWrapper>
+          </ConditionalLink>
         </div>
         <div
           css={css`
@@ -97,22 +91,18 @@ export default function ProgramWorkplaceStatus() {
             height: 50px;
           `}
         >
-          <LinkWrapper
-            access={currentUserStatus}
-            wrapper={(children: ReactNode) => (
-              <Link
-                href={PROGRAM_CLINICAL_SUBMISSION_PATH}
-                as={PROGRAM_CLINICAL_SUBMISSION_PATH.replace(
-                  PROGRAM_SHORT_NAME_PATH,
-                  programShortName as string,
-                )}
-              >
-                <Hyperlink>{children}</Hyperlink>
-              </Link>
-            )}
+          <ConditionalLink
+            showAsLink={canViewLinks}
+            link={{
+              href: PROGRAM_CLINICAL_SUBMISSION_PATH,
+              as: PROGRAM_CLINICAL_SUBMISSION_PATH.replace(
+                PROGRAM_SHORT_NAME_PATH,
+                programShortName as string,
+              ),
+            }}
           >
             <Typography variant="label">Clinical Submission</Typography>
-          </LinkWrapper>
+          </ConditionalLink>
         </div>
         <div
           css={css`

--- a/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
@@ -14,7 +14,6 @@ import {
 } from 'global/constants/pages';
 import { DashboardCard } from '../common';
 import { isCollaborator } from 'global/utils/egoJwt';
-import { ReactNode } from 'react';
 import useAuthContext from 'global/hooks/useAuthContext';
 
 const ConditionalLink: React.ComponentType<{

--- a/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
@@ -39,26 +39,26 @@ export default function ProgramWorkplaceStatus() {
   };
   return (
     <DashboardCard cardHeight="170px">
-     <Typography variant="default" component="span">
-          Program Workplace Status
-        </Typography>
+      <Typography variant="default" component="span">
+        Program Workplace Status
+      </Typography>
 
+      <div
+        css={css`
+          height: 50px;
+          display: flex;
+          flex-direction: row;
+          padding-top: 10px;
+        `}
+      >
         <div
           css={css`
+            margin-top: 7px;
+            width: 175px;
             height: 50px;
-            display: flex;
-            flex-direction: row;
-            padding-top: 10px;
           `}
         >
-          <div
-            css={css`
-              margin-top: 7px;
-              width: 175px;
-              height: 50px;
-            `}
-          >
-            <LinkWrapper
+          <LinkWrapper
             access={currentUserStatus}
             wrapper={(children: ReactNode) => (
               <Link
@@ -74,30 +74,30 @@ export default function ProgramWorkplaceStatus() {
           >
             <Typography variant="label">Sample Registration</Typography>
           </LinkWrapper>
-          </div>
-          <div
-            css={css`
-              height: 50px;
-            `}
-          >
-            <SampleRegistrationProgressBar programShortName={programShortName} />
-          </div>
         </div>
         <div
           css={css`
             height: 50px;
-            display: flex;
-            flex-direction: row;
           `}
         >
-          <div
-            css={css`
-              margin-top: 7px;
-              width: 175px;
-              height: 50px;
-            `}
-          >
-            <LinkWrapper
+          <SampleRegistrationProgressBar programShortName={programShortName} />
+        </div>
+      </div>
+      <div
+        css={css`
+          height: 50px;
+          display: flex;
+          flex-direction: row;
+        `}
+      >
+        <div
+          css={css`
+            margin-top: 7px;
+            width: 175px;
+            height: 50px;
+          `}
+        >
+          <LinkWrapper
             access={currentUserStatus}
             wrapper={(children: ReactNode) => (
               <Link
@@ -113,15 +113,15 @@ export default function ProgramWorkplaceStatus() {
           >
             <Typography variant="label">Clinical Submission</Typography>
           </LinkWrapper>
-          </div>
-          <div
-            css={css`
-              height: 50px;
-            `}
-          >
-            <ClinicalSubmissionProgressBar programShortName={programShortName} />
-          </div>
         </div>
+        <div
+          css={css`
+            height: 50px;
+          `}
+        >
+          <ClinicalSubmissionProgressBar programShortName={programShortName} />
+        </div>
+      </div>
     </DashboardCard>
   );
 }

--- a/uikit/Link/index.tsx
+++ b/uikit/Link/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { styled, css } from '..';
 
 type LinkVariant = 'INLINE' | 'BLOCK';
-type HyperLinkProps = {
+export type HyperLinkProps = {
   variant?: LinkVariant;
   uppercase?: boolean;
   withChevron?: boolean;


### PR DESCRIPTION
**Description of changes**

When on the dashboard, collaborators should not see links to the `sample registration` and `clinical submission` page.

Made a wrapper function that returns the text only if the user is a collaborator, and the regular link otherwise.

<!-- Please add a brief description of the changes here. -->



 PS: For whatever reason github, with this file, is showing some weird diffs that aren't there in my local branch. But whenever I pushed from my local, additional changes kept showing up. The only way I could figure out how to circumvent this was to manually add the changes with github's edit file tool, and not make the changes from my local setup.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [x] Manual testing of UI feature.

