### PR TITLE
🐛 Add invalid_by_migration key to clinical submission sidebar

### DIFF
--- a/components/pages/submission-system/SideMenu.tsx
+++ b/components/pages/submission-system/SideMenu.tsx
@@ -191,6 +191,7 @@ const LinksToProgram = (props: { program: SideMenuProgram; isCurrentlyViewed: bo
                       ),
                       VALID: <Icon name="ellipses" fill="warning" width="15px" />,
                       INVALID: <Icon name="exclamation" fill="error" width="15px" />,
+                      INVALID_BY_MIGRATION: <Icon name="exclamation" fill="error" width="15px" />,
                       PENDING_APPROVAL: <Icon name="lock" fill="accent3_dark" width="15px" />,
                     } as { [k in typeof data.clinicalSubmissions.state]: React.ReactNode })[
                       data ? data.clinicalSubmissions.state : null


### PR DESCRIPTION
**Description of changes**

Adds key to submit clinical data sidebar to handle `INVALID_BY_MIGRATION` state

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
