### PR TITLE
The last admin cannot be removed, a user cannot remove themselves

### DIFF
--- a/components/pages/submission-system/modals/editUser/index.tsx
+++ b/components/pages/submission-system/modals/editUser/index.tsx
@@ -8,10 +8,12 @@ const EditUserModal = ({
   user,
   dismissModal,
   onSubmit,
+  cannotChangeRole,
 }: {
   user: typeof UserModel;
   onSubmit: (data: typeof UserModel) => any | void;
   dismissModal: () => any | void;
+  cannotChangeRole?: boolean;
 }) => {
   const {
     errors,
@@ -23,7 +25,9 @@ const EditUserModal = ({
     hasErrors,
   } = useFormHook({ initialFields: user, schema: userSchema });
   const validationErrors = errors as UserSectionProps['errors'];
-
+  if (!validationErrors.role && cannotChangeRole) {
+    validationErrors.role = 'ADMIN';
+  }
   const submitForm = async () => {
     try {
       const validData = await validateForm();
@@ -33,6 +37,7 @@ const EditUserModal = ({
     }
   };
 
+  const disabledFields = ['email', 'firstName', 'lastName'];
   return (
     <Modal
       title="Edit Users"
@@ -48,7 +53,7 @@ const EditUserModal = ({
         onChange={(key, val) => setData({ key, val })}
         validateField={key => validateField({ key })}
         errors={validationErrors}
-        disabledFields={['email', 'firstName', 'lastName']}
+        disabledFields={cannotChangeRole ? [...disabledFields, 'role'] : disabledFields}
         onClickDelete={null}
       />
       <br />

--- a/components/pages/submission-system/modals/editUser/index.tsx
+++ b/components/pages/submission-system/modals/editUser/index.tsx
@@ -9,12 +9,12 @@ const EditUserModal = ({
   user,
   dismissModal,
   onSubmit,
-  cannotChangeRole,
+  roleDisabled,
 }: {
   user: typeof UserModel;
   onSubmit: (data: typeof UserModel) => any | void;
   dismissModal: () => any | void;
-  cannotChangeRole?: boolean;
+  roleDisabled?: boolean;
 }) => {
   const {
     errors,
@@ -35,10 +35,14 @@ const EditUserModal = ({
     }
   };
 
+  type Field = keyof typeof UserModel;
   const disabledFields = [
-    { fieldName: 'email' },
-    { fieldName: 'firstName' },
-    { fieldName: 'lastName' },
+    { fieldName: 'email' as Field },
+    { fieldName: 'firstName' as Field },
+    { fieldName: 'lastName' as Field },
+    ...(roleDisabled
+      ? [{ fieldName: 'role' as Field, explanationText: adminRestrictionText }]
+      : []),
   ];
 
   return (
@@ -56,11 +60,7 @@ const EditUserModal = ({
         onChange={(key, val) => setData({ key, val })}
         validateField={key => validateField({ key })}
         errors={validationErrors}
-        disabledFields={
-          cannotChangeRole
-            ? [...disabledFields, { fieldName: 'role', explanationText: adminRestrictionText }]
-            : disabledFields
-        }
+        disabledFields={disabledFields}
         onClickDelete={null}
       />
       <br />

--- a/components/pages/submission-system/modals/editUser/index.tsx
+++ b/components/pages/submission-system/modals/editUser/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Modal from 'uikit/Modal';
-import { UserSection, UserSectionProps } from '../styledComponents';
+import { UserSection, UserSectionProps, UserField } from '../styledComponents';
 import { UserModel, userSchema } from '../common';
 import useFormHook from 'global/hooks/useFormHook';
 import { adminRestrictionText } from '../../program-management/Users';
@@ -35,13 +35,12 @@ const EditUserModal = ({
     }
   };
 
-  type Field = keyof typeof UserModel;
-  const disabledFields = [
-    { fieldName: 'email' as Field },
-    { fieldName: 'firstName' as Field },
-    { fieldName: 'lastName' as Field },
+  const disabledFields: Array<UserField> = [
+    { fieldName: 'email' },
+    { fieldName: 'firstName' },
+    { fieldName: 'lastName' },
     ...(roleDisabled
-      ? [{ fieldName: 'role' as Field, explanationText: adminRestrictionText }]
+      ? [{ fieldName: 'role', explanationText: adminRestrictionText } as UserField]
       : []),
   ];
 

--- a/components/pages/submission-system/modals/editUser/index.tsx
+++ b/components/pages/submission-system/modals/editUser/index.tsx
@@ -3,6 +3,7 @@ import Modal from 'uikit/Modal';
 import { UserSection, UserSectionProps } from '../styledComponents';
 import { UserModel, userSchema } from '../common';
 import useFormHook from 'global/hooks/useFormHook';
+import { adminRestrictionText } from '../../program-management/Users';
 
 const EditUserModal = ({
   user,
@@ -25,9 +26,6 @@ const EditUserModal = ({
     hasErrors,
   } = useFormHook({ initialFields: user, schema: userSchema });
   const validationErrors = errors as UserSectionProps['errors'];
-  if (!validationErrors.role && cannotChangeRole) {
-    validationErrors.role = 'ADMIN';
-  }
   const submitForm = async () => {
     try {
       const validData = await validateForm();
@@ -37,7 +35,12 @@ const EditUserModal = ({
     }
   };
 
-  const disabledFields = ['email', 'firstName', 'lastName'];
+  const disabledFields = [
+    { fieldName: 'email' },
+    { fieldName: 'firstName' },
+    { fieldName: 'lastName' },
+  ];
+
   return (
     <Modal
       title="Edit Users"
@@ -53,7 +56,11 @@ const EditUserModal = ({
         onChange={(key, val) => setData({ key, val })}
         validateField={key => validateField({ key })}
         errors={validationErrors}
-        disabledFields={cannotChangeRole ? [...disabledFields, 'role'] : disabledFields}
+        disabledFields={
+          cannotChangeRole
+            ? [...disabledFields, { fieldName: 'role', explanationText: adminRestrictionText }]
+            : disabledFields
+        }
         onClickDelete={null}
       />
       <br />

--- a/components/pages/submission-system/modals/styledComponents.tsx
+++ b/components/pages/submission-system/modals/styledComponents.tsx
@@ -26,7 +26,7 @@ export type UserSectionProps = {
   validateField: (fieldName: keyof typeof UserModel) => unknown | void;
   errors: typeof UserModel;
   onClickDelete: (() => unknown | void) | null;
-  disabledFields: Array<{ fieldName: string; explanationText?: string }>;
+  disabledFields: Array<{ fieldName: keyof typeof UserModel; explanationText?: string }>;
   showDelete?: boolean;
 };
 export const UserSection: React.ComponentType<UserSectionProps> = ({
@@ -44,7 +44,7 @@ export const UserSection: React.ComponentType<UserSectionProps> = ({
     email: emailError,
     role: roleError,
   } = errors;
-  const isDisabledField = (fieldName: string) =>
+  const isDisabledField = (fieldName: keyof typeof UserModel) =>
     disabledFields.some(field => field.fieldName === fieldName);
   const fieldsWithExplanations = disabledFields.filter(entry => entry.explanationText);
   const explanations = Object.fromEntries(

--- a/components/pages/submission-system/modals/styledComponents.tsx
+++ b/components/pages/submission-system/modals/styledComponents.tsx
@@ -20,13 +20,15 @@ const Section = styled('div')`
   display: flex;
 `;
 
+export type UserField = { fieldName: keyof typeof UserModel; explanationText?: string };
+
 export type UserSectionProps = {
   user: typeof UserModel;
   onChange: (fieldName: keyof typeof UserModel, value: unknown) => unknown | void;
   validateField: (fieldName: keyof typeof UserModel) => unknown | void;
   errors: typeof UserModel;
   onClickDelete: (() => unknown | void) | null;
-  disabledFields: Array<{ fieldName: keyof typeof UserModel; explanationText?: string }>;
+  disabledFields: Array<UserField>;
   showDelete?: boolean;
 };
 export const UserSection: React.ComponentType<UserSectionProps> = ({

--- a/components/pages/submission-system/modals/styledComponents.tsx
+++ b/components/pages/submission-system/modals/styledComponents.tsx
@@ -26,7 +26,7 @@ export type UserSectionProps = {
   validateField: (fieldName: keyof typeof UserModel) => unknown | void;
   errors: typeof UserModel;
   onClickDelete: (() => unknown | void) | null;
-  disabledFields: Array<string | void>;
+  disabledFields: Array<{ fieldName: string; explanationText?: string }>;
   showDelete?: boolean;
 };
 export const UserSection: React.ComponentType<UserSectionProps> = ({
@@ -44,7 +44,12 @@ export const UserSection: React.ComponentType<UserSectionProps> = ({
     email: emailError,
     role: roleError,
   } = errors;
-
+  const isDisabledField = (fieldName: string) =>
+    disabledFields.some(field => field.fieldName === fieldName);
+  const fieldsWithExplanations = disabledFields.filter(entry => entry.explanationText);
+  const explanations = Object.fromEntries(
+    fieldsWithExplanations.map(field => [field.fieldName, field.explanationText]),
+  );
   return (
     <Section>
       <div
@@ -55,11 +60,7 @@ export const UserSection: React.ComponentType<UserSectionProps> = ({
       >
         <Row nogutter>
           <Col sm={6} style={{ paddingRight: '10px' }}>
-            <FormControl
-              error={!!firstNameError}
-              disabled={disabledFields.includes('firstName')}
-              required
-            >
+            <FormControl error={!!firstNameError} disabled={isDisabledField('firstName')} required>
               <Row nogutter>
                 <Col sm={4} style={{ paddingTop: 6 }}>
                   <InputLabel>First Name</InputLabel>
@@ -77,11 +78,7 @@ export const UserSection: React.ComponentType<UserSectionProps> = ({
             </FormControl>
           </Col>
           <Col sm={6} style={{ paddingRight: '10px' }}>
-            <FormControl
-              error={!!lastNameError}
-              disabled={disabledFields.includes('lastName')}
-              required
-            >
+            <FormControl error={!!lastNameError} disabled={isDisabledField('lastName')} required>
               <Row nogutter>
                 <Col sm={4} style={{ paddingTop: 6 }}>
                   <InputLabel>Last Name</InputLabel>
@@ -101,7 +98,7 @@ export const UserSection: React.ComponentType<UserSectionProps> = ({
         </Row>
         <Row nogutter>
           <Col sm={6} style={{ paddingRight: '10px' }}>
-            <FormControl error={!!emailError} disabled={disabledFields.includes('email')} required>
+            <FormControl error={!!emailError} disabled={isDisabledField('email')} required>
               <Row nogutter>
                 <Col sm={4} style={{ paddingTop: 6 }}>
                   <InputLabel>Email Address</InputLabel>
@@ -119,7 +116,7 @@ export const UserSection: React.ComponentType<UserSectionProps> = ({
             </FormControl>
           </Col>
           <Col sm={6} style={{ paddingRight: '10px' }}>
-            <FormControl error={!!roleError} disabled={disabledFields.includes('role')} required>
+            <FormControl error={!!roleError} required disabled={isDisabledField('role')}>
               <Row nogutter>
                 <Col sm={4} style={{ paddingTop: 6 }}>
                   <InputLabel>Role</InputLabel>
@@ -127,10 +124,12 @@ export const UserSection: React.ComponentType<UserSectionProps> = ({
                 <Col>
                   <Select
                     aria-label="Select role"
+                    disabled={isDisabledField('role')}
                     value={user.role}
                     options={PROGRAM_USER_ROLES}
                     onChange={val => onChange('role', val)}
                     onBlur={() => validateField('role')}
+                    hintText={isDisabledField('role') ? explanations.role : null}
                   />
                   {!!roleError ? <FormHelperText>{roleError}</FormHelperText> : null}
                 </Col>

--- a/components/pages/submission-system/program-management/Users.tsx
+++ b/components/pages/submission-system/program-management/Users.tsx
@@ -44,6 +44,8 @@ const Users = ({
   useModalViewAnalyticsEffect(`USER_REMOVE_MODAL`, !!currentDeletingUser);
   useModalViewAnalyticsEffect(`USER_EMAIL_RESEND_MODAL`, !!currentResendEmailUser);
 
+  const isOnlyOneAdminLeft = users.filter(user => user.role === 'ADMIN').length <= 1;
+
   return (
     <div>
       <TableActionBar>{users.length} results</TableActionBar>
@@ -56,6 +58,7 @@ const Users = ({
         onUserDeleteClick={({ user }) => setCurrentDeletingUser(user)}
         onUserResendInviteClick={({ user }) => setCurrentResendEmailUser(user)}
         onUserEditClick={({ user }) => setCurrentEditingUser(user)}
+        isOnlyOneAdminLeft={isOnlyOneAdminLeft}
       />
       {!!currentResendEmailUser && (
         <ModalPortal>
@@ -141,6 +144,7 @@ const Users = ({
               setCurrentEditingUser(null);
             }}
             dismissModal={() => setCurrentEditingUser(null)}
+            cannotChangeRole={isOnlyOneAdminLeft && currentEditingUser.role === 'ADMIN'}
           />
         </ModalPortal>
       )}

--- a/components/pages/submission-system/program-management/Users.tsx
+++ b/components/pages/submission-system/program-management/Users.tsx
@@ -19,6 +19,8 @@ import EDIT_USER_MUTATION from './EDIT_USER_MUTATION.gql';
 import REMOVE_USER_MUTATION from './REMOVE_USER_MUTATION.gql';
 import INVITE_USER_MUTATION from './INVITE_USER_MUTATION.gql';
 
+export const adminRestrictionText = 'A program must have at least one Program Administrator';
+
 const Users = ({
   users,
   programShortName,

--- a/components/pages/submission-system/program-management/Users.tsx
+++ b/components/pages/submission-system/program-management/Users.tsx
@@ -146,7 +146,7 @@ const Users = ({
               setCurrentEditingUser(null);
             }}
             dismissModal={() => setCurrentEditingUser(null)}
-            cannotChangeRole={isOnlyOneAdminLeft && currentEditingUser.role === 'ADMIN'}
+            roleDisabled={isOnlyOneAdminLeft && currentEditingUser.role === 'ADMIN'}
           />
         </ModalPortal>
       )}

--- a/components/pages/submission-system/program-management/UsersTable.tsx
+++ b/components/pages/submission-system/program-management/UsersTable.tsx
@@ -7,6 +7,7 @@ import Table, { TableColumnConfig } from 'uikit/Table';
 import InteractiveIcon from 'uikit/Table/InteractiveIcon';
 import Tooltip from 'uikit/Tooltip';
 import { RoleDisplayName, RoleKey } from '../modals/common';
+import { adminRestrictionText } from './Users';
 
 type StatusKey = 'ACCEPTED' | 'PENDING' | 'EXPIRED';
 
@@ -121,10 +122,7 @@ const UsersTable = (tableProps: {
               position="left"
               html={
                 <span>
-                  {isUserTheLastAdmin(props.original)
-                    ? 'A program must have at least one Program Administrator'
-                    : 'Remove User'}
-                  }
+                  {isUserTheLastAdmin(props.original) ? adminRestrictionText : 'Remove User'}
                 </span>
               }
             >

--- a/components/pages/submission-system/program-management/UsersTable.tsx
+++ b/components/pages/submission-system/program-management/UsersTable.tsx
@@ -35,10 +35,13 @@ const UsersTable = (tableProps: {
   onUserDeleteClick: ({ user: UsersTableUser }) => void;
   onUserResendInviteClick: ({ user: UsersTableUser }) => void;
   loading: boolean;
+  isOnlyOneAdminLeft: boolean;
 }) => {
   const { data: egoTokenData } = useAuthContext();
   const userEmail = egoTokenData ? egoTokenData.context.user.email : '';
-
+  const isUserThemselves = (user: UsersTableUser) => user.email === userEmail;
+  const isUserTheLastAdmin = (user: UsersTableUser) =>
+    tableProps.isOnlyOneAdminLeft && user.role === 'ADMIN';
   const columns: Array<TableColumnConfig<UsersTableUser>> = [
     {
       Header: 'Name',
@@ -79,49 +82,63 @@ const UsersTable = (tableProps: {
       sortable: false,
       headerStyle: { display: 'flex', justifyContent: 'center' },
       width: 125,
-      Cell: (props: CellProps) => (
-        <div
-          css={css`
-            flex: 1;
-            display: flex;
-            justify-content: space-around;
-          `}
-        >
-          <Tooltip unmountHTMLWhenHide position="left" html={<span>Resend invitation</span>}>
-            <InteractiveIcon
-              height="20px"
-              width="20px"
-              name="mail"
-              onClick={() => tableProps.onUserResendInviteClick({ user: props.original })}
-              disabled={
-                // Disable if:
-                // already accepted
-                props.original.inviteStatus === 'ACCEPTED' ||
-                // OR added without invitation (shows as Accepted)
-                props.original.inviteStatus === null ||
-                // OR the site user is the user in this row
-                userEmail === props.original.email
+      Cell: (props: CellProps) => {
+        return (
+          <div
+            css={css`
+              flex: 1;
+              display: flex;
+              justify-content: space-around;
+            `}
+          >
+            <Tooltip unmountHTMLWhenHide position="left" html={<span>Resend invitation</span>}>
+              <InteractiveIcon
+                height="20px"
+                width="20px"
+                name="mail"
+                onClick={() => tableProps.onUserResendInviteClick({ user: props.original })}
+                disabled={
+                  // Disable if:
+                  // already accepted
+                  props.original.inviteStatus === 'ACCEPTED' ||
+                  // OR added without invitation (shows as Accepted)
+                  props.original.inviteStatus === null ||
+                  // OR the site user is the user in this row
+                  isUserThemselves(props.original)
+                }
+              />
+            </Tooltip>
+            <Tooltip unmountHTMLWhenHide position="left" html={<span>Edit user</span>}>
+              <InteractiveIcon
+                height="20px"
+                width="20px"
+                name="edit"
+                onClick={() => tableProps.onUserEditClick({ user: props.original })}
+              />
+            </Tooltip>
+            <Tooltip
+              unmountHTMLWhenHide
+              position="left"
+              html={
+                <span>
+                  {isUserTheLastAdmin(props.original)
+                    ? 'A program must have at least one Program Administrator'
+                    : 'Remove User'}
+                  }
+                </span>
               }
-            />
-          </Tooltip>
-          <Tooltip unmountHTMLWhenHide position="left" html={<span>Edit user</span>}>
-            <InteractiveIcon
-              height="20px"
-              width="20px"
-              name="edit"
-              onClick={() => tableProps.onUserEditClick({ user: props.original })}
-            />
-          </Tooltip>
-          <Tooltip unmountHTMLWhenHide position="left" html={<span>Remove user</span>}>
-            <InteractiveIcon
-              height="20px"
-              width="20px"
-              name="trash"
-              onClick={() => tableProps.onUserDeleteClick({ user: props.original })}
-            />
-          </Tooltip>
-        </div>
-      ),
+            >
+              <InteractiveIcon
+                disabled={isUserTheLastAdmin(props.original) || isUserThemselves(props.original)}
+                height="20px"
+                width="20px"
+                name="trash"
+                onClick={() => tableProps.onUserDeleteClick({ user: props.original })}
+              />
+            </Tooltip>
+          </div>
+        );
+      },
     },
   ];
   const containerRef = React.createRef<HTMLDivElement>();

--- a/components/pages/submission-system/program-management/UsersTable.tsx
+++ b/components/pages/submission-system/program-management/UsersTable.tsx
@@ -83,60 +83,58 @@ const UsersTable = (tableProps: {
       sortable: false,
       headerStyle: { display: 'flex', justifyContent: 'center' },
       width: 125,
-      Cell: (props: CellProps) => {
-        return (
-          <div
-            css={css`
-              flex: 1;
-              display: flex;
-              justify-content: space-around;
-            `}
-          >
-            <Tooltip unmountHTMLWhenHide position="left" html={<span>Resend invitation</span>}>
-              <InteractiveIcon
-                height="20px"
-                width="20px"
-                name="mail"
-                onClick={() => tableProps.onUserResendInviteClick({ user: props.original })}
-                disabled={
-                  // Disable if:
-                  // already accepted
-                  props.original.inviteStatus === 'ACCEPTED' ||
-                  // OR added without invitation (shows as Accepted)
-                  props.original.inviteStatus === null ||
-                  // OR the site user is the user in this row
-                  isUserThemselves(props.original)
-                }
-              />
-            </Tooltip>
-            <Tooltip unmountHTMLWhenHide position="left" html={<span>Edit user</span>}>
-              <InteractiveIcon
-                height="20px"
-                width="20px"
-                name="edit"
-                onClick={() => tableProps.onUserEditClick({ user: props.original })}
-              />
-            </Tooltip>
-            <Tooltip
-              unmountHTMLWhenHide
-              position="left"
-              html={
-                <span>
-                  {isUserTheLastAdmin(props.original) ? adminRestrictionText : 'Remove User'}
-                </span>
+      Cell: (props: CellProps) => (
+        <div
+          css={css`
+            flex: 1;
+            display: flex;
+            justify-content: space-around;
+          `}
+        >
+          <Tooltip unmountHTMLWhenHide position="left" html={<span>Resend invitation</span>}>
+            <InteractiveIcon
+              height="20px"
+              width="20px"
+              name="mail"
+              onClick={() => tableProps.onUserResendInviteClick({ user: props.original })}
+              disabled={
+                // Disable if:
+                // already accepted
+                props.original.inviteStatus === 'ACCEPTED' ||
+                // OR added without invitation (shows as Accepted)
+                props.original.inviteStatus === null ||
+                // OR the site user is the user in this row
+                isUserThemselves(props.original)
               }
-            >
-              <InteractiveIcon
-                disabled={isUserTheLastAdmin(props.original) || isUserThemselves(props.original)}
-                height="20px"
-                width="20px"
-                name="trash"
-                onClick={() => tableProps.onUserDeleteClick({ user: props.original })}
-              />
-            </Tooltip>
-          </div>
-        );
-      },
+            />
+          </Tooltip>
+          <Tooltip unmountHTMLWhenHide position="left" html={<span>Edit user</span>}>
+            <InteractiveIcon
+              height="20px"
+              width="20px"
+              name="edit"
+              onClick={() => tableProps.onUserEditClick({ user: props.original })}
+            />
+          </Tooltip>
+          <Tooltip
+            unmountHTMLWhenHide
+            position="left"
+            html={
+              <span>
+                {isUserTheLastAdmin(props.original) ? adminRestrictionText : 'Remove User'}
+              </span>
+            }
+          >
+            <InteractiveIcon
+              disabled={isUserTheLastAdmin(props.original) || isUserThemselves(props.original)}
+              height="20px"
+              width="20px"
+              name="trash"
+              onClick={() => tableProps.onUserDeleteClick({ user: props.original })}
+            />
+          </Tooltip>
+        </div>
+      ),
     },
   ];
   const containerRef = React.createRef<HTMLDivElement>();

--- a/uikit/form/Select/index.tsx
+++ b/uikit/form/Select/index.tsx
@@ -12,6 +12,7 @@ import {
   PopupPosition,
 } from './styledComponents';
 import useTheme from '../../utils/useTheme';
+import Tooltip from 'uikit/Tooltip';
 
 const Select: React.ComponentType<{
   ['aria-label']: string;
@@ -31,6 +32,7 @@ const Select: React.ComponentType<{
   value?: string;
   className?: string;
   style?: React.CSSProperties;
+  hintText?: string;
 }> = ({
   placeholder = '- Select an option -',
   id,
@@ -80,6 +82,37 @@ const Select: React.ComponentType<{
     return () => document.removeEventListener('mouseup', documentClickHandler);
   }, [isExpanded]);
 
+  const styledInputWrapper = (
+    <StyledInputWrapper
+      ref={wrapperRef}
+      id={id}
+      size={size}
+      style={{ zIndex: 1 }}
+      disabled={disabled}
+      inputState={activeState as StyledInputWrapperProps['inputState']}
+      role="button"
+    >
+      <Typography
+        variant="paragraph"
+        color={
+          disabled
+            ? theme.input.textColors.disabled
+            : isSomethingSelected || isExpanded
+            ? 'black'
+            : 'grey'
+        }
+        css={css`
+          flex: 1;
+          padding: 0 10px;
+          line-height: 0;
+        `}
+      >
+        {(value && selectedOption ? selectedOption.content : false) || placeholder}
+      </Typography>
+      <DropdownIcon disabled={disabled} theme={theme} />
+    </StyledInputWrapper>
+  );
+
   return (
     <div
       className={props.className}
@@ -123,34 +156,13 @@ const Select: React.ComponentType<{
           </option>
         ))}
       </HiddenSelect>
-      <StyledInputWrapper
-        ref={wrapperRef}
-        id={id}
-        size={size}
-        style={{ zIndex: 1 }}
-        disabled={disabled}
-        inputState={activeState as StyledInputWrapperProps['inputState']}
-        role="button"
-      >
-        <Typography
-          variant="paragraph"
-          color={
-            disabled
-              ? theme.input.textColors.disabled
-              : isSomethingSelected || isExpanded
-              ? 'black'
-              : 'grey'
-          }
-          css={css`
-            flex: 1;
-            padding: 0 10px;
-            line-height: 0;
-          `}
-        >
-          {(value && selectedOption ? selectedOption.content : false) || placeholder}
-        </Typography>
-        <DropdownIcon disabled={disabled} theme={theme} />
-      </StyledInputWrapper>
+      {props.hintText ? (
+        <Tooltip unmountHTMLWhenHide position="bottom" html={<span>{props.hintText}</span>}>
+          {styledInputWrapper}
+        </Tooltip>
+      ) : (
+        styledInputWrapper
+      )}
       {isExpanded && (
         <OptionsList role="listbox" id={`${id}-options`} className={popupPosition}>
           {options.map(({ content, value: optionValue }) => (

--- a/uikit/form/Select/stories.tsx
+++ b/uikit/form/Select/stories.tsx
@@ -18,6 +18,7 @@ const createKnobs = () => {
     },
     'sm',
   );
+  const hintText = text('Hint Text', '');
 
   return {
     error,
@@ -25,6 +26,7 @@ const createKnobs = () => {
     disabled,
     placeholder,
     size,
+    hintText,
   };
 };
 


### PR DESCRIPTION
**Description of changes**

- A user cannot remove themselves from the manage users table
- A user cannot be removed if they are the last remaining admin
    - the 1) **delete icon** and the 2) **edit user modal -> role dropdown** will be disabled if this is the case
    - a tooltip on these components will show an explanation as to why


**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
