### PR TITLE
💄 1111 - Add margin bottom to scroll container to give role menu more space

### DIFF
--- a/components/pages/submission-system/modals/addUser/index.tsx
+++ b/components/pages/submission-system/modals/addUser/index.tsx
@@ -131,12 +131,7 @@ const AddUserModal = ({
     >
       When you add users, they will receive an email inviting them to register. Note: the provided
       email address must be a Gmail or G Suite email address for login purposes.
-      <div
-        css={css`
-          overflow-y: scroll;
-          max-height: 250px;
-        `}
-      >
+      <div>
         {formIds.map((id, index) => (
           <AddUser
             key={id}

--- a/components/pages/submission-system/modals/editUser/index.tsx
+++ b/components/pages/submission-system/modals/editUser/index.tsx
@@ -54,14 +54,17 @@ const EditUserModal = ({
       onCancelClick={dismissModal}
       onCloseClick={dismissModal}
     >
-      <UserSection
-        user={form}
-        onChange={(key, val) => setData({ key, val })}
-        validateField={key => validateField({ key })}
-        errors={validationErrors}
-        disabledFields={disabledFields}
-        onClickDelete={null}
-      />
+      {/* added extra margin at bottom to prevent scrolling from modal body, give role dropdown display room */}
+      <div style={{ marginBottom: 40 }}>
+        <UserSection
+          user={form}
+          onChange={(key, val) => setData({ key, val })}
+          validateField={key => validateField({ key })}
+          errors={validationErrors}
+          disabledFields={disabledFields}
+          onClickDelete={null}
+        />
+      </div>
       <br />
     </Modal>
   );

--- a/uikit/Modal/index.tsx
+++ b/uikit/Modal/index.tsx
@@ -28,9 +28,9 @@ const ModalTitle = styled('div')`
 `;
 const ModalBody = styled('div')`
   margin-top: 24px;
+  margin-bottom: 24px;
 `;
 const ModalFooter = styled('div')`
-  margin-top: 24px;
   padding: 8px 0px;
   border-top: solid 1px ${({ theme }) => theme.colors.grey_2};
   display: flex;
@@ -122,7 +122,7 @@ const ModalComponent: React.ComponentType<{
       <div
         css={css`
           display: flex;
-          overflow: scroll;
+          overflow-y: auto;
         `}
       >
         {titleIconConfig.name && (


### PR DESCRIPTION
**Description of changes**

Adds margin to bottom of scrolling container instead of modal footer to give role dropdown room to display
Modal will scroll when enough users added
Added extra margin-bottom to Edit Users modal to prevent auto scroll, give dropdown room

**Type of Change**

- [x] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
