### PR TITLE
Build Static State for Dashboard table

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -1,6 +1,7 @@
 NODE_PATH=./
 NODE_ENV=development | production
 AUTH_DISABLED=false
+DASHBOARD_ENABLED=false
 
 ######### Gateway API
 GATEWAY_API_ROOT=http://localhost:9000

--- a/components/pages/submission-system/common.tsx
+++ b/components/pages/submission-system/common.tsx
@@ -1,7 +1,7 @@
 import { displayDateAndTime } from 'global/utils/common';
 import urlJoin from 'url-join';
 import { css, styled } from 'uikit';
-import Icon from 'uikit/Icon';
+import Icon, { Outline } from 'uikit/Icon';
 import { ThemeColorNames } from 'uikit/theme/types';
 import Typography from 'uikit/Typography';
 import { formatFileName } from './program-sample-registration/util';
@@ -36,8 +36,8 @@ export const CellContentCenter = styled('div')`
   align-items: center;
 `;
 
-export const DataTableStarIcon = (props: { fill: keyof ThemeColorNames }) => (
-  <Icon name="star" fill={props.fill} width="16px" height="16px" />
+export const DataTableStarIcon = (props: { fill: keyof ThemeColorNames; outline?: Outline }) => (
+  <Icon name="star" width="16px" height="16px" {...props} />
 );
 export const StatArea: {
   Container: React.ComponentType;
@@ -137,15 +137,17 @@ export const SubmissionInfoArea = ({
 export const TableInfoHeaderContainer = ({
   left,
   right,
+  noMargin,
 }: {
   left?: React.ReactNode;
   right?: React.ReactNode;
+  noMargin?: boolean;
 }) => {
   const theme = useTheme();
   return (
     <div
       css={css`
-        margin-bottom: 3px;
+        margin-bottom: ${noMargin ? '0px' : '3px'};
         border-radius: 2px;
         background-color: ${theme.colors.grey_3};
         padding: 8px;

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
@@ -1,0 +1,362 @@
+import { ReleasedFilesState, DonorEntityRecord, ProcessingStates, PipelineStats } from './types';
+import Table, { TableColumnConfig } from 'uikit/Table';
+
+import { displayDate } from 'global/utils/common';
+import Icon from 'uikit/Icon';
+import {
+  DataTableStarIcon,
+  StatArea as StatAreaDisplay,
+  TableInfoHeaderContainer,
+  CellContentCenter,
+} from '../../common';
+
+import { createRef } from 'react';
+import Link from 'next/link';
+import { useTheme } from 'uikit/ThemeProvider';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import HyperLink from 'uikit/Link';
+import Pipe from 'uikit/Pipe';
+
+const StarIcon = DataTableStarIcon;
+
+type ReleasedStats = {
+  fullyCount: number;
+  partiallyCount: number;
+  noCount: number;
+};
+
+const PROCESSING_STATUS: {
+  COMPLETE: ProcessingStates;
+  PROCESSING: ProcessingStates;
+  REGISTERED: ProcessingStates;
+} = {
+  COMPLETE: 'Complete',
+  PROCESSING: 'Processing',
+  REGISTERED: 'Registered',
+};
+
+const PIPELINE_STATUS: {
+  COMPLETE: keyof PipelineStats;
+  IN_PROGRESS: keyof PipelineStats;
+  ERROR: keyof PipelineStats;
+} = {
+  COMPLETE: 'complete',
+  IN_PROGRESS: 'inProgress',
+  ERROR: 'error',
+};
+
+const RELEASED_STATE_FILL_COLOURS: {
+  [k in ReleasedFilesState]: React.ComponentProps<typeof StarIcon>['fill']
+} = {
+  FULLY: 'secondary',
+  PARTIALLY: 'secondary_2',
+  NO: 'white',
+};
+
+const RELEASED_STATE_STROKE_COLOURS: {
+  [k in ReleasedFilesState]: React.ComponentProps<typeof StarIcon>['outline']
+} = {
+  FULLY: null,
+  PARTIALLY: null,
+  NO: { color: 'secondary', width: 1 },
+};
+
+const DonorStatsArea = ({ stats, total }: { stats: ReleasedStats; total: number }) => {
+  return (
+    <StatAreaDisplay.Container>
+      <StatAreaDisplay.Section>{total} donors</StatAreaDisplay.Section>
+      <StatAreaDisplay.Section>
+        <Icon name="chevron_right" fill="grey_1" width="8px" />
+      </StatAreaDisplay.Section>
+      <StatAreaDisplay.Section>
+        <StatAreaDisplay.StatEntryContainer>
+          <StatAreaDisplay.StarIcon fill={RELEASED_STATE_FILL_COLOURS.FULLY} />
+          {stats.fullyCount} with fully released files
+        </StatAreaDisplay.StatEntryContainer>
+      </StatAreaDisplay.Section>
+      <StatAreaDisplay.Section>
+        <StatAreaDisplay.StatEntryContainer>
+          <StatAreaDisplay.StarIcon fill={RELEASED_STATE_FILL_COLOURS.PARTIALLY} />
+          {stats.partiallyCount} with partially released files
+        </StatAreaDisplay.StatEntryContainer>
+      </StatAreaDisplay.Section>
+      <StatAreaDisplay.Section>
+        <StatAreaDisplay.StatEntryContainer>
+          <StatAreaDisplay.StarIcon
+            fill={RELEASED_STATE_FILL_COLOURS.NO}
+            outline={RELEASED_STATE_STROKE_COLOURS.NO}
+          />
+          {stats.noCount} with no released files
+        </StatAreaDisplay.StatEntryContainer>
+      </StatAreaDisplay.Section>
+    </StatAreaDisplay.Container>
+  );
+};
+
+export default ({ donors }: { donors: Array<DonorEntityRecord> }) => {
+  const containerRef = createRef<HTMLDivElement>();
+  const checkmarkIcon = <Icon name="checkmark" fill="accent1_dimmed" width="12px" height="12px" />;
+
+  const StatusColumnCell = ({ original }: { original: DonorEntityRecord }) => {
+    return (
+      <CellContentCenter>
+        <StarIcon
+          fill={RELEASED_STATE_FILL_COLOURS[original.releaseState]}
+          outline={RELEASED_STATE_STROKE_COLOURS[original.releaseState]}
+        />
+      </CellContentCenter>
+    );
+  };
+
+  const PercentageCell = ({
+    original,
+    fieldName,
+  }: {
+    original: DonorEntityRecord;
+    fieldName: 'coreFields' | 'extendedFields';
+  }) => {
+    const cellContent =
+      original[fieldName] === 100
+        ? checkmarkIcon
+        : original[fieldName] === 0
+        ? ''
+        : `${original[fieldName]}%`;
+    return (
+      <div
+        css={css`
+          padding-left: 4px;
+        `}
+      >
+        {cellContent}
+      </div>
+    );
+  };
+
+  const DesignationCell = ({
+    original,
+    fieldName,
+  }: {
+    original: DonorEntityRecord;
+    fieldName: 'samples' | 'rawReads';
+  }) => {
+    const theme = useTheme();
+    const isValid = (num: number) => num > 0;
+    const DesignationContainer = styled('div')`
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+    `;
+    const DesignationEntry = styled('div')`
+      text-align: center;
+      flex: 1;
+      color: ${(props: { num: number }) =>
+        isValid(props.num) ? theme.colors.black : theme.colors.error};
+    `;
+
+    const numNormal = original[fieldName].normal;
+    const numTumour = original.samples.tumour;
+    return (
+      <DesignationContainer>
+        <DesignationEntry num={numNormal}>{numNormal}N</DesignationEntry>
+        <DesignationEntry
+          num={numTumour}
+          css={css`
+            border-left: solid 1px ${theme.colors.grey_2};
+          `}
+        >
+          {numTumour}T
+        </DesignationEntry>
+      </DesignationContainer>
+    );
+  };
+
+  const ProcessingCell = ({ original }: { original: DonorEntityRecord }) => {
+    const getIcon = (state: ProcessingStates) =>
+      ({
+        [PROCESSING_STATUS.COMPLETE]: checkmarkIcon,
+        [PROCESSING_STATUS.PROCESSING]: (
+          <Icon width="12px" height="12px" fill="warning_dark" name="ellipses" />
+        ),
+        [PROCESSING_STATUS.REGISTERED]: (
+          <Icon width="12px" height="12px" fill="primary_2" name="dash" />
+        ),
+      }[state]);
+
+    return (
+      <div
+        css={css`
+          display: flex;
+          flex-direction: row;
+          justify-content: flex-start;
+          align-items: center;
+          width: 70%;
+        `}
+      >
+        <div
+          css={css`
+            padding: 4px 8px 0px 0px;
+          `}
+        >
+          {getIcon(original.processingStatus)}
+        </div>
+        <div>{original.processingStatus}</div>
+      </div>
+    );
+  };
+
+  const PipelineCell = ({
+    original,
+    fieldName,
+  }: {
+    original: DonorEntityRecord;
+    fieldName: 'alignment' | 'sangerVC';
+  }) => {
+    const theme = useTheme();
+
+    const getBackgroundColour = (state: keyof PipelineStats) => {
+      interface ColourMapper {
+        [key: string]: keyof typeof theme.colors;
+      }
+      const mapper: ColourMapper = {
+        [PIPELINE_STATUS.COMPLETE]: 'accent1_dimmed',
+        [PIPELINE_STATUS.IN_PROGRESS]: 'warning_dark',
+        [PIPELINE_STATUS.ERROR]: 'error',
+      };
+      return mapper[state];
+    };
+
+    const shouldRender = (num: number) => num > 0;
+
+    const renderableStats = Object.keys(original[fieldName]).filter(key =>
+      shouldRender(original[fieldName][key]),
+    );
+
+    const pipeStats = renderableStats.map(stat => (
+      <Pipe.Item key={stat} fill={getBackgroundColour(stat as keyof PipelineStats)}>
+        {original[fieldName][stat]}
+      </Pipe.Item>
+    ));
+    return <Pipe>{pipeStats}</Pipe>;
+  };
+
+  const tableColumns: Array<TableColumnConfig<DonorEntityRecord>> = [
+    {
+      Header: 'CLINICAL DATA STATUS',
+      headerStyle: {
+        background: useTheme().colors.secondary_4,
+      },
+      columns: [
+        {
+          Header: (
+            <CellContentCenter>
+              <StarIcon fill={'grey_1'} />
+            </CellContentCenter>
+          ),
+          Cell: StatusColumnCell,
+          accessor: 'releaseState',
+          resizable: false,
+          width: 50,
+          sortMethod: (a: ReleasedFilesState, b: ReleasedFilesState) => {
+            const priorities = {
+              NO: 1,
+              PARTIALLY: 2,
+              FULLY: 3,
+            } as { [k in ReleasedFilesState]: number };
+            return priorities[a] - priorities[b];
+          },
+        },
+        {
+          Header: 'Donor ID',
+          accessor: 'donorID',
+          Cell: ({ original }: { original: DonorEntityRecord }) => {
+            return (
+              <Link href="">
+                <HyperLink>{original.donorId}</HyperLink>
+              </Link>
+            );
+          },
+        },
+        {
+          Header: 'Core Fields',
+          accessor: 'coreFields',
+          Cell: ({ original }) => <PercentageCell original={original} fieldName={'coreFields'} />,
+        },
+        {
+          Header: 'Extended Fields',
+          accessor: 'extendedFields',
+          Cell: ({ original }) => (
+            <PercentageCell original={original} fieldName={'extendedFields'} />
+          ),
+        },
+        {
+          Header: 'Samples',
+          accessor: 'samples',
+          Cell: ({ original }) => <DesignationCell original={original} fieldName={'samples'} />,
+          width: 100,
+        },
+      ],
+    },
+    {
+      Header: 'DNA-SEQ PIPELINE',
+      headerStyle: {
+        background: useTheme().colors.accent3_3,
+      },
+      columns: [
+        {
+          Header: 'Raw Reads',
+          accessor: 'rawReads',
+          Cell: ({ original }) => <DesignationCell original={original} fieldName={'rawReads'} />,
+          width: 100,
+        },
+        {
+          Header: 'Alignment',
+          accessor: 'alignment',
+          Cell: ({ original }) => <PipelineCell original={original} fieldName={'alignment'} />,
+        },
+        {
+          Header: 'Sanger VC',
+          accessor: 'sangerVC',
+          Cell: ({ original }) => <PipelineCell original={original} fieldName={'sangerVC'} />,
+        },
+      ],
+    },
+    {
+      columns: [
+        {
+          Header: 'Processing Status',
+          accessor: 'processingStatus',
+          Cell: ProcessingCell,
+        },
+        {
+          Header: 'Last Updated',
+          accessor: 'lastUpdated',
+          Cell: ({ original }: { original: DonorEntityRecord }) => {
+            return <div>{displayDate(original.lastUpdated)}</div>;
+          },
+        },
+      ],
+    },
+  ];
+
+  const getStateCount = (allDonors: Array<DonorEntityRecord>, releaseState: ReleasedFilesState) =>
+    allDonors.filter(donor => donor.releaseState === releaseState).length;
+
+  const stateCountSummary: ReleasedStats = {
+    fullyCount: getStateCount(donors, 'FULLY'),
+    partiallyCount: getStateCount(donors, 'PARTIALLY'),
+    noCount: getStateCount(donors, 'NO'),
+  };
+
+  return (
+    <div ref={containerRef}>
+      <TableInfoHeaderContainer
+        left={<DonorStatsArea total={donors.length} stats={stateCountSummary} />}
+        noMargin={true}
+      />
+      <Table parentRef={containerRef} showPagination={false} columns={tableColumns} data={donors} />
+    </div>
+  );
+};

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/common.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/common.tsx
@@ -1,0 +1,134 @@
+import { DonorEntityRecord } from './types';
+
+export const dummyDonorData: Array<DonorEntityRecord> = [
+  {
+    releaseState: 'FULLY',
+    donorId: 'DO1 (ICGC_0001)',
+    coreFields: 100,
+    extendedFields: 23,
+    samples: {
+      normal: 1,
+      tumour: 1,
+    },
+    rawReads: {
+      normal: 1,
+      tumour: 1,
+    },
+    alignment: {
+      complete: 2,
+      inProgress: 0,
+      error: 0,
+    },
+    sangerVC: {
+      complete: 1,
+      inProgress: 0,
+      error: 0,
+    },
+    processingStatus: 'Complete',
+    lastUpdated: '2020/01/22',
+  },
+  {
+    releaseState: 'FULLY',
+    donorId: 'DO3 (ICGC_0003)',
+    coreFields: 100,
+    extendedFields: 29,
+    samples: {
+      normal: 2,
+      tumour: 3,
+    },
+    rawReads: {
+      normal: 2,
+      tumour: 2,
+    },
+    alignment: {
+      complete: 2,
+      inProgress: 1,
+      error: 1,
+    },
+    sangerVC: {
+      complete: 1,
+      inProgress: 0,
+      error: 0,
+    },
+    processingStatus: 'Processing',
+    lastUpdated: '2020/04/13',
+  },
+  {
+    releaseState: 'PARTIALLY',
+    donorId: 'DO124 (ICGC_5434)',
+    coreFields: 100,
+    extendedFields: 0,
+    samples: {
+      normal: 2,
+      tumour: 0,
+    },
+    rawReads: {
+      normal: 2,
+      tumour: 2,
+    },
+    alignment: {
+      complete: 3,
+      inProgress: 1,
+      error: 0,
+    },
+    sangerVC: {
+      complete: 2,
+      inProgress: 2,
+      error: 0,
+    },
+    processingStatus: 'Processing',
+    lastUpdated: '2020/03/20',
+  },
+  {
+    releaseState: 'NO',
+    donorId: 'DO129 (ICGC_0123)',
+    coreFields: 10,
+    extendedFields: 0,
+    samples: {
+      normal: 1,
+      tumour: 1,
+    },
+    rawReads: {
+      normal: 0,
+      tumour: 0,
+    },
+    alignment: {
+      complete: 0,
+      inProgress: 0,
+      error: 0,
+    },
+    sangerVC: {
+      complete: 0,
+      inProgress: 0,
+      error: 0,
+    },
+    processingStatus: 'Registered',
+    lastUpdated: '2020/02/25',
+  },
+  {
+    releaseState: 'NO',
+    donorId: 'DO1245 (ICGC_0124)',
+    coreFields: 0,
+    extendedFields: 0,
+    samples: {
+      normal: 1,
+      tumour: 1,
+    },
+    rawReads: {
+      normal: 1,
+      tumour: 1,
+    },
+    alignment: {
+      complete: 0,
+      inProgress: 1,
+      error: 1,
+    },
+    sangerVC: {
+      complete: 0,
+      inProgress: 0,
+      error: 0,
+    },
+    processingStatus: 'Processing',
+    lastUpdated: '2020/03/03',
+  },
+];

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/index.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/index.tsx
@@ -11,7 +11,9 @@ import { DashboardCard } from '../common';
 import { getConfig } from 'global/config';
 import urljoin from 'url-join';
 import { DOCS_SUBMITTED_DATA_PATH } from 'global/constants/pages';
-const { DOCS_URL_ROOT } = getConfig();
+import DonorSummaryTable from './DonorSummaryTable';
+import { dummyDonorData } from './common';
+const { DOCS_URL_ROOT, DASHBOARD_ENABLED } = getConfig();
 
 const getStartedLink = (
   <Typography variant="data" component="span">
@@ -26,24 +28,40 @@ const NoDataIcon = styled('img')`
   max-width: 100vw;
 `;
 
-export default () => (
-  <DashboardCard>
-    <Typography variant="default" component="span">
-      Donor Data Summary
-    </Typography>
-    <NoData title="You do not have any donor data submitted." link={getStartedLink}>
-      <div
-        css={css`
-          display: flex;
-          flex-wrap: wrap;
-          justify-content: space-around;
-          max-height: 100%;
-        `}
-      >
-        <NoDataIcon alt="no data found" src={PicBeakers} />
-        <NoDataIcon alt="no data found" src={PicHeart} />
-        <NoDataIcon alt="no data found" src={PicDna} />
-      </div>
-    </NoData>
-  </DashboardCard>
+const emptyState = (
+  <NoData title="You do not have any donor data submitted." link={getStartedLink}>
+    <div
+      css={css`
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-around;
+        max-height: 100%;
+      `}
+    >
+      <NoDataIcon alt="no data found" src={PicBeakers} />
+      <NoDataIcon alt="no data found" src={PicHeart} />
+      <NoDataIcon alt="no data found" src={PicDna} />
+    </div>
+  </NoData>
 );
+
+const readyState = (
+  <div
+    css={css`
+      padding-top: 10px;
+    `}
+  >
+    <DonorSummaryTable donors={dummyDonorData} />
+  </div>
+);
+
+export default () => {
+  return (
+    <DashboardCard>
+      <Typography variant="default" component="span">
+        Donor Data Summary
+      </Typography>
+      {DASHBOARD_ENABLED ? readyState : emptyState}
+    </DashboardCard>
+  );
+};

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/types.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/types.tsx
@@ -1,0 +1,27 @@
+export type DonorEntityRecord = {
+  releaseState: ReleasedFilesState;
+  donorId: string;
+  coreFields: number;
+  extendedFields: number;
+  samples: TumourDesignationPair;
+  rawReads: TumourDesignationPair;
+  alignment: PipelineStats;
+  sangerVC: PipelineStats;
+  processingStatus: ProcessingStates;
+  lastUpdated: Date | String;
+};
+
+export type ReleasedFilesState = 'FULLY' | 'PARTIALLY' | 'NO';
+
+export type TumourDesignationPair = {
+  normal: number;
+  tumour: number;
+};
+
+export type PipelineStats = {
+  complete: number;
+  inProgress: number;
+  error: number;
+};
+
+export type ProcessingStates = 'Registered' | 'Processing' | 'Complete';

--- a/global/config.ts
+++ b/global/config.ts
@@ -18,6 +18,7 @@ export const getConfig = () => {
       `/api/oauth/login/google?client_id=${publicConfig.EGO_CLIENT_ID || ''}`,
     ),
     DOCS_URL_ROOT: publicConfig.DOCS_URL_ROOT || 'https://docs.icgc-argo.org/docs/',
+    DASHBOARD_ENABLED: publicConfig.DASHBOARD_ENABLED === 'true',
   } as {
     GATEWAY_API_ROOT: string;
     EGO_API_ROOT: string;
@@ -27,5 +28,6 @@ export const getConfig = () => {
     GA_TRACKING_ID: string;
     EGO_URL: string;
     DOCS_URL_ROOT: string;
+    DASHBOARD_ENABLED: boolean;
   };
 };

--- a/next.config.js
+++ b/next.config.js
@@ -37,5 +37,6 @@ module.exports = withImages({
     AUTH_DISABLED: process.env.AUTH_DISABLED,
     GA_TRACKING_ID: process.env.GA_TRACKING_ID,
     DOCS_URL_ROOT: process.env.DOCS_URL_ROOT,
+    DASHBOARD_ENABLED: process.env.DASHBOARD_ENABLED,
   },
 });

--- a/uikit/Icon/icons/collection/dash.tsx
+++ b/uikit/Icon/icons/collection/dash.tsx
@@ -1,0 +1,11 @@
+import { css } from '@emotion/core';
+
+export default {
+  title: 'Dash',
+  viewBox: '0 0 20 20',
+  path: 'M2 8 H18 A2 2 0 0 1 20 10 V10 A2 2 0 0 1 18 12 H2 A2 2 0 0 1 0 10 V10 A2 2 0 0 1 2 8 z',
+  css: css`
+    width: 20px;
+    height: 20px;
+  `,
+};

--- a/uikit/Icon/icons/index.tsx
+++ b/uikit/Icon/icons/index.tsx
@@ -29,6 +29,7 @@ import star from './collection/star';
 import download from './collection/download';
 import upload from './collection/upload';
 import lock from './collection/lock';
+import dash from './collection/dash';
 /**
  * Icon path and property lookup object
  * css - sensible defaults - can be overridden from component
@@ -65,6 +66,7 @@ const Icons = {
   download,
   upload,
   lock,
+  dash,
 };
 
 export type UikitIconNames = keyof typeof Icons;

--- a/uikit/Icon/index.tsx
+++ b/uikit/Icon/index.tsx
@@ -7,7 +7,8 @@ import defaultTheme from '../theme/defaultTheme';
 import { ThemeColorNames } from '../theme/types';
 import { UikitIconNames } from './icons';
 import { SvgProperties } from 'csstype';
-
+import get from 'lodash/get';
+export type Outline = { color: keyof ThemeColorNames | string; width: number };
 const Icon: React.ComponentType<
   {
     name: UikitIconNames;
@@ -16,8 +17,9 @@ const Icon: React.ComponentType<
     width?: string;
     height?: string;
     fill?: keyof ThemeColorNames | string;
+    outline?: Outline;
   } & SVGAttributes<SVGElement>
-> = ({ name, width, height, fill, className, title, ...rest }) => {
+> = ({ name, width, height, fill, className, title, outline, ...rest }) => {
   const theme = useTheme();
   const svg: Omit<typeof icons[typeof name], 'fillRule'> & {
     mask?: string;
@@ -28,6 +30,9 @@ const Icon: React.ComponentType<
   } = icons[name];
 
   const resolveFill = (fill?: string): string | undefined => (fill && theme.colors[fill]) || fill;
+
+  const resolveOutline = (outline?: Outline) =>
+    outline ? { ...outline, color: resolveFill(outline.color) } : null;
 
   return (
     <svg
@@ -55,6 +60,8 @@ const Icon: React.ComponentType<
             <path
               key={i}
               fill={pathDef.fill || resolveFill(fill) || pathDef.defaultFill || svg.defaultFill}
+              stroke={get(resolveOutline(outline), 'color', null)}
+              strokeWidth={get(resolveOutline(outline), 'width', null)}
               fillRule={pathDef.fillRule || svg.fillRule || 'nonzero'}
               d={pathDef.d}
               mask={pathDef.mask || svg.mask ? 'url(#mask)' : ''}
@@ -63,6 +70,8 @@ const Icon: React.ComponentType<
         ) : (
           <path
             fill={resolveFill(fill) || svg.defaultFill}
+            stroke={get(resolveOutline(outline), 'color', null)}
+            strokeWidth={get(resolveOutline(outline), 'width', null)}
             fillRule={(svg.fillRule as SVGAttributes<SVGPathElement>['fillRule']) || 'nonzero'}
             d={svg.path}
             mask={svg.mask ? 'url(#mask)' : ''}

--- a/uikit/Pipe/index.tsx
+++ b/uikit/Pipe/index.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+import defaultTheme from 'uikit/theme/defaultTheme';
+
+const PipeContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  color: white;
+  font-size: 11px;
+  font-weight: bold;
+  line-height: 1.27;
+  letter-spacing: normal;
+  text-align: center;
+  width: 100%;
+  padding: 5px;
+  height: 10px;
+`;
+
+const PipeItem = styled<'div', { fill: keyof typeof defaultTheme.colors }>('div')`
+  flex-grow: 1;
+  background-color: ${({ theme, fill }) => theme.colors[fill]};
+  margin-right: 2px;
+
+  &:only-child {
+    margin: 0px;
+    border-radius: 10px;
+  }
+
+  &:first-of-type:not(:last-of-type) {
+    border-radius: 10px 0 0 10px;
+  }
+  &:last-of-type:not(:first-of-type) {
+    margin: 0px;
+    border-radius: 0 10px 10px 0;
+  }
+`;
+
+const Pipe: React.ComponentType<{}> & { Item: typeof PipeItem } = ({ children }) => (
+  <PipeContainer>{children}</PipeContainer>
+);
+
+Pipe.Item = PipeItem;
+
+export default Pipe;

--- a/uikit/Pipe/stories.tsx
+++ b/uikit/Pipe/stories.tsx
@@ -1,0 +1,54 @@
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import css from '@emotion/css';
+import Pipe from '.';
+import { text, select } from '@storybook/addon-knobs';
+
+import defaultTheme from '../theme/defaultTheme';
+const themeColors = Object.keys(defaultTheme.colors);
+
+const PipeStories = storiesOf(`${__dirname}`, module).add('Basic', () => {
+  const colourKnobs = [
+    select('Fill Colour: First', themeColors, 'accent1_dimmed', null),
+    select('Fill Colour: Second', themeColors, 'warning_dark', null),
+    select('Fill Colour: Third', themeColors, 'error', null),
+  ];
+  const childrenKnobs = [
+    text('Text: First', '2'),
+    text('Text: Second', '4'),
+    text('Text: Third', '5'),
+  ];
+
+  return (
+    <div
+      css={css`
+        margin: auto;
+        width: 50%;
+        height: 200px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-around;
+        align-items: stretch;
+      `}
+    >
+      <Pipe>
+        <Pipe.Item fill={colourKnobs[0]}>{childrenKnobs[0]}</Pipe.Item>
+        <Pipe.Item fill={colourKnobs[1]}>{childrenKnobs[1]}</Pipe.Item>
+        <Pipe.Item fill={colourKnobs[2]}>{childrenKnobs[2]}</Pipe.Item>
+      </Pipe>
+      <Pipe>
+        <Pipe.Item fill={'accent3_dark'}>Just One Child</Pipe.Item>
+      </Pipe>
+      <Pipe>
+        <Pipe.Item fill={'accent2'}>Or Many</Pipe.Item>
+        <Pipe.Item fill={'secondary_dark'}>2</Pipe.Item>
+        <Pipe.Item fill={'accent4_dark'}>1</Pipe.Item>
+        <Pipe.Item fill={'accent2'}>9</Pipe.Item>
+        <Pipe.Item fill={'secondary_dark'}>4</Pipe.Item>
+        <Pipe.Item fill={'accent4_dark'}>8</Pipe.Item>
+      </Pipe>
+    </div>
+  );
+});
+
+export default PipeStories;

--- a/uikit/Table/styledComponent.tsx
+++ b/uikit/Table/styledComponent.tsx
@@ -75,6 +75,14 @@ export const StyledTable = styled<typeof ReactTable, StyledTableProps>(ReactTabl
     }
   }
 
+  &.ReactTable .rt-thead.-headerGroups {
+    ${({ theme }) => css(theme.typography.data)};
+    background: ${({ theme }) => theme.colors.grey_2};
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 1.27;
+  }
+
   &.ReactTable .rt-tbody .rt-td {
     ${({ theme }) => css(theme.typography.data)}
     min-height: 28px;


### PR DESCRIPTION
**Description of changes**
<img width="1155" alt="donor data summary screenshot" src="https://user-images.githubusercontent.com/59613607/76355382-9206a600-62ea-11ea-9b82-449a4dad74e0.png">

- Built the donor summary table static state for the dashboard page ([zepplin ref](https://app.zeplin.io/project/5a69fad2bde6330a929157fd/screen/5deeac22f471a10775935a47)) .
- Defined the columns and the cell styles
- Defined the types for the table data
- Created 5 dummy records for demonstration purposes
- Dashboard render state is set by an environment variable

What was not done / other notes:
- sorting logic for some of the complicated cells (i.e samples, alignment)
- adding the filtering buttons and submenus
- integration with any data or states
- small scope change with the samples / raw reads column. Rendered both data into one cell rather than the colspan / merge cell like the ui mockup initially had


**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- [x] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [x] New uikit components have Storybook stories
- [x] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
