### PR TITLE
Rely on default tab

### DIFF
--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -93,10 +93,14 @@ const gqlClinicalEntityToClinicalSubmissionEntityFile = (
 export default () => {
   const { shortName: programShortName } = usePageQuery<{ shortName: string }>();
   const { setLoading: setPageLoaderShown } = useGlobalLoadingState();
+
+  // not declared as a side effect that changes with program change
+  // change in 'data' always seems to take precedence over currentFileList within `defaultClinicalEntityType`
   const [currentFileList, setCurrentFileList] = React.useState<{
     fileList: FileList | null;
     shortName: string;
   }>({ fileList: null, shortName: programShortName });
+
   const {
     isModalShown: signOffModalShown,
     getUserConfirmation: getSignOffConfirmation,
@@ -127,6 +131,9 @@ export default () => {
       data.clinicalSubmissions.clinicalEntities
         .map(e => e.clinicalType)
         .find(entityType => !!file.name.match(new RegExp(`^${entityType}.*\\.tsv`)));
+
+    // currentfilelist state can persist when the program changes
+    // ensure currentfilelist is specific to the current program, so sorting does not get affected by different program
     const lastUploadedEntityTypes =
       currentFileList.shortName === programShortName
         ? uniq(map(currentFileList.fileList, fileToClinicalEntityType))

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -165,6 +165,7 @@ export default () => {
   >(UPLOAD_CLINICAL_SUBMISSION, {
     onCompleted: () => {
       setSelectedClinicalEntityType(defaultClinicalEntityType);
+      setCurrentFileList(null);
     },
   });
   const [validateSubmission] = useMutation<

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -110,7 +110,7 @@ export default () => {
     refetch,
   } = useClinicalSubmissionQuery(programShortName, {
     onCompleted: () => {
-      setSelectedClinicalEntityType(selectedClinicalEntityType || defaultClinicalEntityType);
+      setSelectedClinicalEntityType(defaultClinicalEntityType);
     },
   });
 

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -132,8 +132,9 @@ export default () => {
         .map(e => e.clinicalType)
         .find(entityType => !!file.name.match(new RegExp(`^${entityType}.*\\.tsv`)));
 
-    // currentfilelist state can persist when the program changes
-    // ensure currentfilelist is specific to the current program, so sorting does not get affected by different program
+    // currentfileList state can persist when the program changes
+    // ensure currentfileList is specific to the current program, so sorting does not get affected by different program
+    // adding currentFileList to the dependency list array had no effect (https://github.com/icgc-argo/platform-ui/pull/1220)
     const lastUploadedEntityTypes =
       currentFileList.shortName === programShortName
         ? uniq(map(currentFileList.fileList, fileToClinicalEntityType))


### PR DESCRIPTION
**Description of changes**

Under a program's clinical submission, if one of the files, (i.e. `donor.tsv`) had a priority status (i.e. `ERROR`), that tab would become the `selectedClinicalEntityType`.

When jumping straight to another program's clinical submission (on its first load), where a different file has priority status (i.e. `Specimen.tsv` is set to `WARNING`) the `selectedClinicalEntityType` tab would short circuit the logic and the intended tab with priority would not be highlighted.

Removed `selectedClinicalEntityType` in the condition.



**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
