### PR TITLE
🐛Clinical Error state would not show in side tab

### DIFF
--- a/components/pages/submission-system/SideMenu.tsx
+++ b/components/pages/submission-system/SideMenu.tsx
@@ -193,6 +193,8 @@ const LinksToProgram = (props: { program: SideMenuProgram; isCurrentlyViewed: bo
                       INVALID: <Icon name="exclamation" fill="error" width="15px" />,
                       INVALID_BY_MIGRATION: <Icon name="exclamation" fill="error" width="15px" />,
                       PENDING_APPROVAL: <Icon name="lock" fill="accent3_dark" width="15px" />,
+                      // submission state remains as null and rejects creating open state with initial invalid upload
+                      // if errors exist, error icon should still show up despite the null state
                       null: clinicalSubmissionHasSchemaErrors ? (
                         <Icon name="exclamation" fill="error" width="15px" />
                       ) : null,

--- a/components/pages/submission-system/SideMenu.tsx
+++ b/components/pages/submission-system/SideMenu.tsx
@@ -193,6 +193,9 @@ const LinksToProgram = (props: { program: SideMenuProgram; isCurrentlyViewed: bo
                       INVALID: <Icon name="exclamation" fill="error" width="15px" />,
                       INVALID_BY_MIGRATION: <Icon name="exclamation" fill="error" width="15px" />,
                       PENDING_APPROVAL: <Icon name="lock" fill="accent3_dark" width="15px" />,
+                      null: clinicalSubmissionHasSchemaErrors ? (
+                        <Icon name="exclamation" fill="error" width="15px" />
+                      ) : null,
                     } as { [k in typeof data.clinicalSubmissions.state]: React.ReactNode })[
                       data ? data.clinicalSubmissions.state : null
                     ]

--- a/components/pages/submission-system/SideMenu.tsx
+++ b/components/pages/submission-system/SideMenu.tsx
@@ -195,7 +195,7 @@ const LinksToProgram = (props: { program: SideMenuProgram; isCurrentlyViewed: bo
                       PENDING_APPROVAL: <Icon name="lock" fill="accent3_dark" width="15px" />,
                       // submission state remains as null and rejects creating open state with initial invalid upload
                       // if errors exist, error icon should still show up despite the null state
-                      null: clinicalSubmissionHasSchemaErrors ? (
+                      [null as any]: clinicalSubmissionHasSchemaErrors ? (
                         <Icon name="exclamation" fill="error" width="15px" />
                       ) : null,
                     } as { [k in typeof data.clinicalSubmissions.state]: React.ReactNode })[

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -100,6 +100,7 @@ export default () => {
     fileList: FileList | null;
     shortName: string;
   }>({ fileList: null, shortName: programShortName });
+
   const {
     isModalShown: signOffModalShown,
     getUserConfirmation: getSignOffConfirmation,

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -180,6 +180,7 @@ export default () => {
   >(UPLOAD_CLINICAL_SUBMISSION, {
     onCompleted: () => {
       setSelectedClinicalEntityType(defaultClinicalEntityType);
+      setCurrentFileList(null);
     },
   });
   const [validateSubmission] = useMutation<

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -100,7 +100,6 @@ export default () => {
     fileList: FileList | null;
     shortName: string;
   }>({ fileList: null, shortName: programShortName });
-
   const {
     isModalShown: signOffModalShown,
     getUserConfirmation: getSignOffConfirmation,
@@ -180,7 +179,6 @@ export default () => {
   >(UPLOAD_CLINICAL_SUBMISSION, {
     onCompleted: () => {
       setSelectedClinicalEntityType(defaultClinicalEntityType);
-      setCurrentFileList(null);
     },
   });
   const [validateSubmission] = useMutation<


### PR DESCRIPTION
**Description of changes**

- If the **first** file you try uploading in a clinical submission is an invalid one, it appears that the submission state remains as "null", ie. does not enter the `open` state

- In these cases, the side tab, then would not show an error state.

- Ensured that even in these null cases, error would show if they existed


<!-- Please add a brief description of the changes here. -->

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
