### PR TITLE
🐛 Create queue for refresh request to prevent parallel refreshes

### DIFF
--- a/global/hooks/useAuthContext.tsx
+++ b/global/hooks/useAuthContext.tsx
@@ -23,7 +23,6 @@ const AuthContext = React.createContext<T_AuthContext>({
   data: null,
   fetchWithEgoToken: fetch,
 });
-let refreshJwtPromise = null;
 
 export function AuthProvider({
   egoJwt,
@@ -65,15 +64,13 @@ export function AuthProvider({
       headers: { ...((options && options.headers) || {}), authorization: `Bearer ${token || ''}` },
     };
 
-    if (token && !isValidJwt(token) && !refreshJwtPromise) {
-      refreshJwtPromise = refreshJwt(token);
-      const newJwt = await refreshJwtPromise;
+    if (token && !isValidJwt(token)) {
+      const newJwt = await refreshJwt();
       if (isValidJwt(newJwt)) {
         setToken(newJwt);
       } else {
         logOut();
       }
-      refreshJwtPromise = null;
       return fetch(uri, {
         ...modifiedOption,
         headers: { ...modifiedOption.headers, authorization: `Bearer ${newJwt}` },

--- a/global/utils/refreshJwt.ts
+++ b/global/utils/refreshJwt.ts
@@ -12,7 +12,7 @@ var maxQueue = Infinity;
 var queue = new Queue(maxConcurrent, maxQueue);
 
 // pass client_id to get ego api to set correct response headers
-const refreshUrl = urlJoin(EGO_API_ROOT, `/oauth/refresh?client_id=${EGO_CLIENT_ID}`);
+const refreshUrl = urlJoin(EGO_API_ROOT, `/api/oauth/refresh?client_id=${EGO_CLIENT_ID}`);
 
 export default () =>
   queue.add(() => {

--- a/global/utils/refreshJwt.ts
+++ b/global/utils/refreshJwt.ts
@@ -1,17 +1,34 @@
 import urlJoin from 'url-join';
 import { getConfig } from 'global/config';
+import Cookies from 'js-cookie';
+import { EGO_JWT_KEY } from 'global/constants';
+import { isValidJwt } from './egoJwt';
+import Queue from 'promise-queue';
 
 const { EGO_API_ROOT, EGO_CLIENT_ID } = getConfig();
 
-// pass client_id to get ego api to set correct response headers
-const refreshUrl = urlJoin(EGO_API_ROOT, `/api/oauth/refresh?client_id=${EGO_CLIENT_ID}`);
+var maxConcurrent = 1;
+var maxQueue = Infinity;
+var queue = new Queue(maxConcurrent, maxQueue);
 
-export default egoJwt =>
-  fetch(refreshUrl, {
-    credentials: 'include',
-    headers: {
-      accept: '*/*',
-      authorization: egoJwt || '',
-    },
-    method: 'POST',
-  }).then(res => res.text());
+// pass client_id to get ego api to set correct response headers
+const refreshUrl = urlJoin(EGO_API_ROOT, `/oauth/refresh?client_id=${EGO_CLIENT_ID}`);
+
+export default () =>
+  queue.add(() => {
+    return fetch(refreshUrl, {
+      credentials: 'include',
+      headers: {
+        accept: '*/*',
+        authorization: Cookies.get(EGO_JWT_KEY) || '',
+      },
+      method: 'POST',
+    })
+      .then(res => res.text())
+      .then(newJwt => {
+        if (isValidJwt(newJwt)) {
+          Cookies.set(EGO_JWT_KEY, newJwt);
+        }
+        return newJwt;
+      });
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19814,6 +19814,11 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
+    "promise-queue": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
+      "integrity": "sha1-L29ffA9tCBCelnZZx5uIqe1ek7Q="
+    },
     "promise.allsettled": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "node-fetch": "^2.6.0",
     "npm": "^6.13.1",
     "pluralize": "^8.0.0",
+    "promise-queue": "^2.2.5",
     "prop-types": "^15.7.2",
     "query-string": "^6.11.0",
     "react": "^16.8.6",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -84,7 +84,7 @@ class Root extends App<
             Cookies.remove(EGO_JWT_KEY);
             redirect(res, `${LOGIN_PAGE_PATH}?redirect=${encodeURI(ctx.asPath)}`);
           };
-          const newJwt = (await refreshJwt(egoJwt).catch(forceLogin)) as string;
+          const newJwt = (await refreshJwt().catch(forceLogin)) as string;
           if (isValidJwt(newJwt)) {
             Cookies.set(EGO_JWT_KEY, newJwt);
             refreshedJwt = newJwt;


### PR DESCRIPTION
**Description of changes**

Create queue for refresh requests to prevent more than one refresh happening at once.
Get jwt from cookies inside refresh function

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
