### PR TITLE
🐛 take control of the loading state instead of apollo to avoid pollin…

### DIFF
--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
@@ -305,9 +305,6 @@ export default ({
     } = {},
   } = useProgramDonorsSummaryQuery(programShortName, first, offset, sorts, {
     onCompleted: () => {
-      if (loaderTimeout) {
-        clearTimeout(loaderTimeout);
-      }
       setLoaderTimeout(
         setTimeout(() => {
           setIsTableLoading(false);
@@ -319,6 +316,9 @@ export default ({
   const [isTableLoading, setIsTableLoading] = React.useState(isCardLoading);
 
   const handlePagingStateChange = (state: typeof pagingState) => {
+    if (loaderTimeout) {
+      clearTimeout(loaderTimeout);
+    }
     setIsTableLoading(true);
     Promise.resolve().then(() => {
       setPagingState(state);

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
@@ -321,6 +321,7 @@ export default ({
     }
     setIsTableLoading(true);
     Promise.resolve().then(() => {
+      // this is to push the pagination state render to the next tick
       setPagingState(state);
     });
   };


### PR DESCRIPTION
Polling causes the loader to show up every few seconds. This PR takes control of the loading state away from apollo and makes the loader show up on every paging navigation.