### PR TITLE
🐛 Add noGutter prop to homepage rows

### DIFF
--- a/components/pages/Homepage/common.tsx
+++ b/components/pages/Homepage/common.tsx
@@ -33,6 +33,7 @@ export const DataReleaseBar: React.ComponentType<{
           flex-direction: column;
           justify-content: center;
           text-align: center;
+          margin: 0 5%;
         `}
       >
         <div>
@@ -77,7 +78,7 @@ export const DataReleaseBar: React.ComponentType<{
           border-top: 4px solid ${theme.colors.accent3_2};
         `}
       >
-        <Row>{formattedStats}</Row>
+        <Row nogutter>{formattedStats}</Row>
       </div>
     </div>
   );
@@ -190,12 +191,12 @@ export const NewsContainer: React.ComponentType<{ newsItems: JSX.Element[] }> = 
   return (
     <Container
       css={css`
-        margin: 50px 0px;
+        margin: 50px 0px 35px 0px;
         overflow: hidden;
       `}
     >
-      <Row>
-        <Col md={4} sm={12} style={{ padding: '0px 0px 0px 15px' }}>
+      <Row nogutter>
+        <Col md={4} sm={12}>
           <div
             css={css`
               background-image: linear-gradient(
@@ -291,6 +292,8 @@ export const ResourceBox: React.ComponentType<{
     <Link underline={false} href={href} target="_blank">
       <Container
         css={css`
+          height: 75%;
+          margin: 0 10px;
           &:hover {
             background-color: ${theme.colors.grey_4};
           }
@@ -357,6 +360,7 @@ export const OvertureBanner: React.ComponentType<{}> = ({}) => {
         justify-content: center;
         align-items: center;
         border-top: 1px solid ${theme.colors.grey_2};
+        background-color: ${theme.colors.grey_4};
       `}
     >
       <Link

--- a/components/pages/Homepage/common.tsx
+++ b/components/pages/Homepage/common.tsx
@@ -121,6 +121,7 @@ export const DataCallout: React.ComponentType<{
         justify-content: space-between;
         text-align: center;
         height: 100%;
+        margin: 0 5%;
       `}
     >
       <div

--- a/components/pages/Homepage/index.tsx
+++ b/components/pages/Homepage/index.tsx
@@ -178,6 +178,7 @@ export default function Homepage() {
             justify-content: space-between;
             align-items: flex-start;
           `}
+          nogutter
         >
           <Col sm={12} md={3.8}>
             <DataCallout

--- a/components/pages/Homepage/index.tsx
+++ b/components/pages/Homepage/index.tsx
@@ -250,7 +250,7 @@ export default function Homepage() {
             padding: 20px 0px;
           `}
         >
-          <Row justify="end">
+          <Row justify="end" nogutter>
             <Col {...layoutProps}>
               <ResourceBox
                 title={'Publication Guidelines'}


### PR DESCRIPTION
**Description of changes**

- React grid systems calculation for row gutters are inconsistent, caused inconsistent renders of padding on the homepage
- Applied nogutter prop to the rows and defined the spacing manually instead

<!-- Please add a brief description of the changes here. -->

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
