### PR TITLE
🐛 Prevent NaN fill amount on percentBar

### DIFF
--- a/uikit/PercentBar/index.tsx
+++ b/uikit/PercentBar/index.tsx
@@ -10,8 +10,9 @@ const PercentBar: React.ComponentType<{
   const theme = useTheme();
 
   // Negative Numbers should be zero, percentages over 100 should be capped
+  // A zero denominator should show as 0% fill
   num < 0 ? (num = 0) : { num };
-  const fraction = Math.min((num / den) * 100, 100);
+  const fraction = den <= 0 ? 0 : Math.min((num / den) * 100, 100);
   const fill_amount = `${fraction}%`;
   const lengthpx = `${length || 120}px`;
 


### PR DESCRIPTION
**Description of changes**

Percent bar set to 0% fill amount when denominator is `0`, prevent NaN result.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
