### PR TITLE
🐛 Reposition tooltip so does not overflow window

### DIFF
--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -125,7 +125,7 @@ export default ({
           >
             <Tooltip
               unmountHTMLWhenHide
-              position="top"
+              position="left"
               html={<span>{downloadStatus.toolTipText}</span>}
             >
               <InteractiveIcon


### PR DESCRIPTION
**Description of changes**

Repositions tooltip to left so it does not overflow window. I couldn't reproduce the double scrollbar but hoping these issues are related.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
