### PR TITLE
:fire: hides primary sites stat and chart

### DIFF
--- a/components/pages/file-repository/StatsCard/StatItem.tsx
+++ b/components/pages/file-repository/StatsCard/StatItem.tsx
@@ -22,7 +22,6 @@ import pluralize from 'pluralize';
 import { css } from 'uikit';
 import { UikitIconNames } from 'uikit/Icon/icons';
 import { capitalize } from 'global/utils/stringUtils';
-import { Col } from 'react-grid-system';
 import { useTheme } from 'uikit/ThemeProvider';
 import Icon from 'uikit/Icon';
 import Typography from 'uikit/Typography';
@@ -44,27 +43,25 @@ const StatItem = ({ iconName, statType, count, loading = false }: StatItemProps)
       : `${count} ${capitalize(pluralize(statType, count))}`;
 
   return (
-    <Col xl={2.4} lg={2.4} md={4} sm={6}>
-      <Typography
+    <Typography
+      css={css`
+        font-size: 14px;
+        margin: 0.8rem 0 0.2rem;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        color: ${theme.colors.primary};
+      `}
+    >
+      <Icon
         css={css`
-          font-size: 14px;
-          margin: 0.8rem 0 0.2rem;
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          color: ${theme.colors.primary};
+          padding-right: 0.3em;
         `}
-      >
-        <Icon
-          css={css`
-            padding-right: 0.3em;
-          `}
-          fill={theme.colors.primary_1}
-          name={iconName}
-        />
-        {loading ? <Icon name={'spinner'} fill={theme.colors.grey} /> : displayStat}
-      </Typography>
-    </Col>
+        fill={theme.colors.primary_1}
+        name={iconName}
+      />
+      {loading ? <Icon name={'spinner'} fill={theme.colors.grey} /> : displayStat}
+    </Typography>
   );
 };
 

--- a/components/pages/file-repository/StatsCard/index.tsx
+++ b/components/pages/file-repository/StatsCard/index.tsx
@@ -25,6 +25,7 @@ import STATS_BAR from './STATS_BAR.gql';
 import useFiltersContext from '../hooks/useFiltersContext';
 import { FileRepoFiltersType } from '../utils/types';
 import { useQuery } from '@apollo/react-hooks';
+import { Col } from 'react-grid-system';
 
 type StatsBarQueryInput = {
   filters: FileRepoFiltersType;
@@ -78,19 +79,36 @@ const StatsCard = () => {
       <PaddedRow
         css={css`
           justify-content: space-around;
-          position: relative;
         `}
       >
-        <StatItem iconName="file" statType="file" count={filesCount} loading={loading} />
-        <StatItem iconName="user" statType="donor" count={donorsCount} loading={loading} />
-        <StatItem
+        <Col md={3} sm={6}>
+          <StatItem iconName="file" statType="file" count={filesCount} loading={loading} />
+        </Col>
+        <Col md={3} sm={6}>
+          <StatItem iconName="user" statType="donor" count={donorsCount} loading={loading} />
+        </Col>
+        {/* <Col md={3} sm={6}></Col><StatItem
           iconName="crosshairs"
           statType="primary site"
           count={primarySites}
           loading={loading}
-        />
-        <StatItem iconName="programs" statType="program" count={programsCount} loading={loading} />
-        <StatItem iconName="filesize" statType="fileSize" count={totalFileSize} loading={loading} />
+        /></Col> */}
+        <Col md={3} sm={6}>
+          <StatItem
+            iconName="programs"
+            statType="program"
+            count={programsCount}
+            loading={loading}
+          />
+        </Col>
+        <Col md={3} sm={6}>
+          <StatItem
+            iconName="filesize"
+            statType="fileSize"
+            count={totalFileSize}
+            loading={loading}
+          />
+        </Col>
       </PaddedRow>
     </Container>
   );

--- a/components/pages/file-repository/index.tsx
+++ b/components/pages/file-repository/index.tsx
@@ -57,13 +57,13 @@ const RepositoryPage = ({ subtitle }: { subtitle?: string }) => {
               <QueryBarContainer />
               <StatsCard />
               <PaddedRow justify="between">
-                <PaddedColumn xl={4} lg={6} md={12}>
+                <PaddedColumn lg={6} md={12}>
                   <FileBarChart />
                 </PaddedColumn>
-                <PaddedColumn xl={4} lg={6} md={12}>
+                {/* <PaddedColumn xl={4} lg={6} md={12}>
                   <PrimarySiteBarChart />
-                </PaddedColumn>
-                <PaddedColumn xl={4} lg={6} md={12}>
+                </PaddedColumn> */}
+                <PaddedColumn lg={6} md={12}>
                   <ProgramBarChart />
                 </PaddedColumn>
               </PaddedRow>


### PR DESCRIPTION
**Description of changes**

- hides primary sites stat and chart for now.
- also moves the `Col` out of `StatItem` into `StatsCard/index` because it's easier to find where to change it when we add back later

**Type of Change**

- [ ] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
