### PR TITLE
:sparkles: implements file repo field displaynames

### DIFF
--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -355,27 +355,27 @@ export default () => {
           </MenuItem>
         </FacetRow>
         {!loadingFieldDisplayNames &&
-          presetFacets.map((type) => {
-            const facetProps = commonFacetProps(type);
+          presetFacets.map((facetDetails) => {
+            const facetProps = commonFacetProps(facetDetails);
 
             return (
-              <FacetRow key={type.name}>
-                {type.variant === 'Basic' && (
+              <FacetRow key={facetDetails.name}>
+                {facetDetails.variant === 'Basic' && (
                   <Facet
                     {...facetProps}
-                    options={getOptions(type)}
+                    options={getOptions(facetDetails)}
                     countUnit={'files'}
-                    onOptionToggle={onFacetOptionToggle(type)}
-                    onSelectAllOptions={onFacetSelectAllOptionsToggle(type)}
+                    onOptionToggle={onFacetOptionToggle(facetDetails)}
+                    onSelectAllOptions={onFacetSelectAllOptionsToggle(facetDetails)}
                     parseDisplayValue={toDisplayValue}
                   />
                 )}
-                {type.variant === 'Number' && (
+                {facetDetails.variant === 'Number' && (
                   <NumberRangeFacet
                     {...facetProps}
-                    onSubmit={onNumberRangeFacetSubmit(type)}
-                    min={numberRangeFacetMin(type)}
-                    max={numberRangeFacetMax(type)}
+                    onSubmit={onNumberRangeFacetSubmit(facetDetails)}
+                    min={numberRangeFacetMin(facetDetails)}
+                    max={numberRangeFacetMax(facetDetails)}
                   />
                 )}
               </FacetRow>

--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -66,43 +66,43 @@ const createPresetFacets = (
   displayNames: ReturnType<typeof useFileCentricFieldDisplayName>['data'],
 ): Array<FacetDetails> => [
   {
-    name: displayNames['study_id'] || '__',
+    name: displayNames['study_id'],
     facetPath: FileFacetPath.study_id,
     variant: 'Basic',
     esDocumentField: FileCentricDocumentField.study_id,
   },
   {
-    name: displayNames['donors.gender'] || '__',
+    name: displayNames['donors.gender'],
     facetPath: FileFacetPath.donors__gender,
     variant: 'Basic',
     esDocumentField: FileCentricDocumentField['donors.gender'],
   },
   {
-    name: displayNames['analysis.experiment.experimental_strategy'] || '__',
+    name: displayNames['analysis.experiment.experimental_strategy'],
     facetPath: FileFacetPath.analysis__experiment__experimental_strategy,
     variant: 'Basic',
     esDocumentField: FileCentricDocumentField['analysis.experiment.experimental_strategy'],
   },
   {
-    name: displayNames['data_type'] || '__',
+    name: displayNames['data_type'],
     facetPath: FileFacetPath.data_type,
     variant: 'Basic',
     esDocumentField: FileCentricDocumentField.data_type,
   },
   {
-    name: displayNames['file_type'] || '__',
+    name: displayNames['file_type'],
     facetPath: FileFacetPath.file_type,
     variant: 'Basic',
     esDocumentField: FileCentricDocumentField.file_type,
   },
   {
-    name: displayNames['variant_class'] || '__',
+    name: displayNames['variant_class'],
     facetPath: FileFacetPath.variant_class,
     variant: 'Basic',
     esDocumentField: FileCentricDocumentField.variant_class,
   },
   {
-    name: displayNames['file_access'] || '__',
+    name: displayNames['file_access'],
     facetPath: FileFacetPath.file_access,
     variant: 'Basic',
     esDocumentField: FileCentricDocumentField.file_access,
@@ -152,9 +152,8 @@ export default () => {
   } = useFileCentricFieldDisplayName();
   const presetFacets = createPresetFacets(fieldDisplayNames);
   const [expandedFacets, setExpandedFacets] = React.useState(
-    [...presetFacets, fileIDSearch].map(facet => facet.facetPath),
+    [...presetFacets, fileIDSearch].map((facet) => facet.facetPath),
   );
-  console.log('presetFacets: ', presetFacets);
   const uploadDisabled = false; // TODO: implement correctly
   const theme = useTheme();
   const { filters, setFilterFromFieldAndValue, replaceAllFilters } = useFiltersContext();
@@ -165,15 +164,15 @@ export default () => {
   const clickHandler = (targetFacet: FacetDetails) => {
     const targetFacetPath = targetFacet.facetPath;
     if (expandedFacets.includes(targetFacetPath)) {
-      setExpandedFacets(expandedFacets.filter(facet => facet !== targetFacetPath));
+      setExpandedFacets(expandedFacets.filter((facet) => facet !== targetFacetPath));
     } else {
       setExpandedFacets(expandedFacets.concat(targetFacetPath));
     }
   };
   const [queriedFileIDs, setQueriedFileIDs] = React.useState('');
 
-  const getOptions: GetAggregationResult = facet => {
-    return (aggregations[facet.facetPath] || { buckets: [] }).buckets.map(bucket => ({
+  const getOptions: GetAggregationResult = (facet) => {
+    return (aggregations[facet.facetPath] || { buckets: [] }).buckets.map((bucket) => ({
       ...bucket,
       isChecked: inCurrentFilters({
         currentFilters: filters,
@@ -234,7 +233,7 @@ export default () => {
           `}
         >
           <MenuItem
-            onClick={e => clickHandler(fileIDSearch)}
+            onClick={(e) => clickHandler(fileIDSearch)}
             selected={expandedFacets.includes(fileIDSearch.facetPath)}
             className="FacetMenu"
             content={fileIDSearch.name}
@@ -245,7 +244,7 @@ export default () => {
             `}
           >
             <div
-              onClick={e => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
               css={css`
                 padding: 6px 12px;
                 border-bottom: 1px solid ${theme.colors.grey_2};
@@ -264,7 +263,7 @@ export default () => {
                 placeholder="e.g. FL9998, DO9898…"
                 preset="search"
                 value={queriedFileIDs}
-                onChange={e => {
+                onChange={(e) => {
                   setQueriedFileIDs(e.target.value);
                 }}
               />
@@ -285,10 +284,9 @@ export default () => {
           </MenuItem>
         </FacetRow>
         {!loadingFieldDisplayNames &&
-          presetFacets.map(type => {
+          presetFacets.map((type) => {
             const commonFacetProps = {
-              onClick: e => {
-                console.log('e: ', e);
+              onClick: (e) => {
                 clickHandler(type);
               },
               isExpanded: expandedFacets.includes(type.facetPath),
@@ -302,14 +300,14 @@ export default () => {
                     {...commonFacetProps}
                     options={getOptions(type)}
                     countUnit={'files'}
-                    onOptionToggle={facetValue => {
+                    onOptionToggle={(facetValue) => {
                       const currentValue = SqonBuilder.has(
                         type.esDocumentField,
                         facetValue,
                       ).build();
                       replaceAllFilters(toggleFilter(currentValue, filters));
                     }}
-                    onSelectAllOptions={allOptionsSelected => {
+                    onSelectAllOptions={(allOptionsSelected) => {
                       if (allOptionsSelected) {
                         const updatedFilters = removeFilter(
                           type.esDocumentField,
@@ -319,7 +317,7 @@ export default () => {
                       } else {
                         setFilterFromFieldAndValue({
                           field: type.esDocumentField,
-                          value: aggregations[type.facetPath].buckets.map(v => v.key),
+                          value: aggregations[type.facetPath].buckets.map((v) => v.key),
                         });
                       }
                     }}

--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -51,10 +51,10 @@ import {
   FileRepoFacetsQueryVariables,
   GetAggregationResult,
 } from './types';
-import { FileCentricDocumentField } from '../FileTable/types';
 import Container from 'uikit/Container';
 import useFileCentricFieldDisplayName from '../hooks/useFileCentricFieldDisplayName';
 import DnaLoader from 'uikit/DnaLoader';
+import { FileCentricDocumentField } from '../types';
 
 const FacetRow = styled('div')`
   display: flex;

--- a/components/pages/file-repository/FacetPanel/types.ts
+++ b/components/pages/file-repository/FacetPanel/types.ts
@@ -1,6 +1,6 @@
 import { FileRepoFiltersType } from '../utils/types';
-import { FileCentricDocumentField } from '../FileTable/types';
 import { FilterOption } from 'uikit/OptionsList';
+import { FileCentricDocumentField } from '../types';
 
 export enum FileFacetPath {
   study_id = 'study_id',

--- a/components/pages/file-repository/FileTable/TsvDownloadButton.tsx
+++ b/components/pages/file-repository/FileTable/TsvDownloadButton.tsx
@@ -30,8 +30,8 @@ import { getConfig } from 'global/config';
 import urlJoin from 'url-join';
 import { MANIFEST_DOWNLOAD_PATH } from 'global/constants/gatewayApiPaths';
 import useFiltersContext, { defaultFilters } from '../hooks/useFiltersContext';
-import { FileCentricDocumentField } from './types';
 import { RecursiveFilter } from '../utils/types';
+import { FileCentricDocumentField } from '../types';
 
 enum DownloadOptionValues {
   ALL_FILES = 'ALL_FILES',
@@ -114,7 +114,7 @@ export default ({
         : defaultFilters,
     ],
   };
-  const onItemClick: DownloadButtonProps<DownloadOptionValues>['onItemClick'] = item => {
+  const onItemClick: DownloadButtonProps<DownloadOptionValues>['onItemClick'] = (item) => {
     switch (item.value) {
       case DownloadOptionValues.SCORE_MANIFEST:
         const downloadUrl = urlJoin(

--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -45,6 +45,7 @@ import { FileRepoFiltersType } from '../utils/types';
 import { SortedChangeFunction } from 'react-table';
 import { useTheme } from 'uikit/ThemeProvider';
 import TsvDownloadButton from './TsvDownloadButton';
+import useFileCentricFieldDisplayName from '../hooks/useFileCentricFieldDisplayName';
 
 const DEFAULT_PAGE_SIZE = 20;
 const DEFAULT_PAGE_OFFSET = 0;
@@ -127,6 +128,8 @@ export default () => {
   const { filters } = useFiltersContext();
   const theme = useTheme();
 
+  const { data: fieldDisplayNames } = useFileCentricFieldDisplayName();
+
   const {
     pagingState,
     onPageChange,
@@ -162,39 +165,39 @@ export default () => {
     TableColumnConfig<FileRepositoryRecord> & { id: FileCentricDocumentField }
   > = [
     {
-      Header: 'Object ID',
+      Header: fieldDisplayNames['object_id'],
       id: FileCentricDocumentField['object_id'],
       accessor: 'objectId',
       width: 275,
     },
     {
-      Header: 'Donor ID',
+      Header: fieldDisplayNames['donors.donor_id'],
       id: FileCentricDocumentField['donors.donor_id'],
       accessor: 'donorId',
     },
     {
-      Header: 'Program ID',
+      Header: fieldDisplayNames['study_id'],
       id: FileCentricDocumentField['study_id'],
       accessor: 'programId',
     },
     {
-      Header: 'Data Type',
+      Header: fieldDisplayNames['data_type'],
       id: FileCentricDocumentField['data_type'],
       accessor: 'dataType',
       width: 180,
     },
     {
-      Header: 'File Type',
+      Header: fieldDisplayNames['file_type'],
       id: FileCentricDocumentField['file_type'],
       accessor: 'fileType',
     },
     {
-      Header: 'Experimental Strategy',
+      Header: fieldDisplayNames['analysis.experiment.experimental_strategy'],
       id: FileCentricDocumentField['analysis.experiment.experimental_strategy'],
       accessor: 'experimentalStrategy',
     },
     {
-      Header: 'Size',
+      Header: fieldDisplayNames['file.size'],
       id: FileCentricDocumentField['file.size'],
       accessor: 'size',
       Cell: ({ original }: { original: FileRepositoryRecord }) => filesize(original.size),

--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -25,7 +25,6 @@ import {
   FileRepositoryTableQueryData,
   FileRepositoryTableQueryVariables,
   FileRepositoryRecordSort,
-  FileCentricDocumentField,
   FileRepositoryRecordSortOrder,
   FileRepositorySortingRule,
 } from './types';
@@ -46,6 +45,7 @@ import { SortedChangeFunction } from 'react-table';
 import { useTheme } from 'uikit/ThemeProvider';
 import TsvDownloadButton from './TsvDownloadButton';
 import useFileCentricFieldDisplayName from '../hooks/useFileCentricFieldDisplayName';
+import { FileCentricDocumentField } from '../types';
 
 const DEFAULT_PAGE_SIZE = 20;
 const DEFAULT_PAGE_OFFSET = 0;
@@ -246,7 +246,7 @@ export default () => {
   const fileRepoEntries: FileRepositoryRecord[] = records
     ? records.file.hits.edges.map(({ node }) => ({
         objectId: node.object_id,
-        donorId: node.donors.hits.edges.map(edge => edge.node.donor_id).join(', '),
+        donorId: node.donors.hits.edges.map((edge) => edge.node.donor_id).join(', '),
         programId: node.study_id,
         dataType: node.data_type,
         experimentalStrategy: node.analysis.experiment.experimental_strategy,

--- a/components/pages/file-repository/FileTable/types.tsx
+++ b/components/pages/file-repository/FileTable/types.tsx
@@ -19,6 +19,7 @@
 
 import { FileRepoFiltersType } from '../utils/types';
 import { SortingRule } from 'react-table';
+import { FileCentricDocumentField } from '../types';
 
 export type FileRepositoryRecord = {
   objectId: string;
@@ -80,18 +81,6 @@ export type FileRepositoryRecordSort = {
   order: FileRepositoryRecordSortOrder;
 };
 
-export enum FileCentricDocumentField {
-  object_id = 'object_id',
-  'donors.donor_id' = 'donors.donor_id',
-  study_id = 'study_id',
-  data_type = 'data_type',
-  file_type = 'file_type',
-  'analysis.experiment.experimental_strategy' = 'analysis.experiment.experimental_strategy',
-  'file.size' = 'file.size',
-  'donors.gender' = 'donors.gender',
-  variant_class = 'variant_class',
-  file_access = 'file_access',
-}
 export type FileRepositoryRecordSortOrder = 'asc' | 'desc';
 
 export type FileRepositorySortingRule = SortingRule & {

--- a/components/pages/file-repository/QueryBar/index.tsx
+++ b/components/pages/file-repository/QueryBar/index.tsx
@@ -26,8 +26,8 @@ import Button from 'uikit/Button';
 import isEmpty from 'lodash/isEmpty';
 import { toDisplayValue } from '../utils';
 import Typography from 'uikit/Typography';
-import { FileCentricDocumentField } from '../FileTable/types';
 import useFileCentricFieldDisplayName from '../hooks/useFileCentricFieldDisplayName';
+import { FileCentricDocumentField } from '../types';
 
 type AndOp = 'and';
 

--- a/components/pages/file-repository/QueryBar/index.tsx
+++ b/components/pages/file-repository/QueryBar/index.tsx
@@ -25,6 +25,9 @@ import { FileRepoFiltersType } from '../utils/types';
 import Button from 'uikit/Button';
 import isEmpty from 'lodash/isEmpty';
 import { toDisplayValue } from '../utils';
+import Typography from 'uikit/Typography';
+import { FileCentricDocumentField } from '../FileTable/types';
+import useFileCentricFieldDisplayName from '../hooks/useFileCentricFieldDisplayName';
 
 type AndOp = 'and';
 
@@ -60,7 +63,7 @@ type Filter = React.FunctionComponent<{
 
 const SQONView = dynamic(() => import('@arranger/components/dist/SQONView')) as Filter;
 const Value = dynamic(() =>
-  import('@arranger/components/dist/SQONView').then(comp => comp.Value),
+  import('@arranger/components/dist/SQONView').then((comp) => comp.Value),
 ) as ValueNode;
 
 const content = css`
@@ -122,12 +125,6 @@ const content = css`
       cursor: pointer;
       text-transform: capitalize;
     }
-    & .sqon-field {
-      font-weight: 600;
-      text-transform: uppercase;
-      margin-right: 0.3rem;
-      font-size: 12px;
-    }
     & .sqon-less,
     .sqon-more {
       background-color: ${theme.colors.secondary_1};
@@ -179,6 +176,23 @@ const content = css`
   }
 `;
 
+const FieldCrumb = ({ field }: { field: FileCentricDocumentField }) => {
+  const { data: fieldDisplayName } = useFileCentricFieldDisplayName();
+  return (
+    <Typography
+      bold
+      css={css`
+        margin: 0px;
+        margin-right: 0.3rem;
+        text-transform: uppercase;
+        font-size: 12px;
+      `}
+    >
+      {fieldDisplayName[field] || field}
+    </Typography>
+  );
+};
+
 const QueryBar = ({ filters }: { filters: FileRepoFiltersType }) => {
   const { clearFilters, setFilterFromFieldAndValue, replaceAllFilters } = useFiltersContext();
 
@@ -192,6 +206,8 @@ const QueryBar = ({ filters }: { filters: FileRepoFiltersType }) => {
             Clear
           </Button>
         )}
+        // @ts-ignore types from arranger is just wrong here, it isn't even ts
+        FieldCrumb={({ field }) => <FieldCrumb field={field} />}
         ValueCrumb={({ field, value, nextSQON, ...props }: any) => (
           <Value
             onClick={() => {

--- a/components/pages/file-repository/hooks/FILE_CENTRIC_EXTENDED_MAPPING.gql
+++ b/components/pages/file-repository/hooks/FILE_CENTRIC_EXTENDED_MAPPING.gql
@@ -1,0 +1,5 @@
+query {
+  file {
+    extended
+  }
+}

--- a/components/pages/file-repository/hooks/useFileCentricFieldDisplayName.tsx
+++ b/components/pages/file-repository/hooks/useFileCentricFieldDisplayName.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/react-hooks';
 import FILE_CENTRIC_EXTENDED_MAPPING from './FILE_CENTRIC_EXTENDED_MAPPING.gql';
-import { FileCentricDocumentField } from '../FileTable/types';
+import { FileCentricDocumentField } from '../types';
 
 type ExtendedMapping = {
   displayName: string;

--- a/components/pages/file-repository/hooks/useFileCentricFieldDisplayName.tsx
+++ b/components/pages/file-repository/hooks/useFileCentricFieldDisplayName.tsx
@@ -8,7 +8,7 @@ type ExtendedMapping = {
 }[];
 
 const useFileCentricFieldDisplayName = (): {
-  data: { [k in FileCentricDocumentField]: string };
+  data: { [k in FileCentricDocumentField]: string } | {};
   loading: boolean;
 } => {
   const { data, loading } = useQuery<{ file: { extended: ExtendedMapping } }>(

--- a/components/pages/file-repository/hooks/useFileCentricFieldDisplayName.tsx
+++ b/components/pages/file-repository/hooks/useFileCentricFieldDisplayName.tsx
@@ -1,0 +1,32 @@
+import { useQuery } from '@apollo/react-hooks';
+import FILE_CENTRIC_EXTENDED_MAPPING from './FILE_CENTRIC_EXTENDED_MAPPING.gql';
+import { FileCentricDocumentField } from '../FileTable/types';
+
+type ExtendedMapping = {
+  displayName: string;
+  field: FileCentricDocumentField;
+}[];
+
+const useFileCentricFieldDisplayName = (): {
+  data: { [k in FileCentricDocumentField]: string };
+  loading: boolean;
+} => {
+  const { data, loading } = useQuery<{ file: { extended: ExtendedMapping } }>(
+    FILE_CENTRIC_EXTENDED_MAPPING,
+  );
+
+  return {
+    // @ts-ignore this will result in unknown fields being present in run time, but that's why we have you Typescript!
+    data: data
+      ? data.file.extended.reduce(
+          (acc, { displayName, field }) => ({
+            ...acc,
+            [field]: displayName,
+          }),
+          {},
+        )
+      : {},
+    loading,
+  };
+};
+export default useFileCentricFieldDisplayName;

--- a/components/pages/file-repository/types.ts
+++ b/components/pages/file-repository/types.ts
@@ -1,0 +1,12 @@
+export enum FileCentricDocumentField {
+  object_id = 'object_id',
+  'donors.donor_id' = 'donors.donor_id',
+  study_id = 'study_id',
+  data_type = 'data_type',
+  file_type = 'file_type',
+  'analysis.experiment.experimental_strategy' = 'analysis.experiment.experimental_strategy',
+  'file.size' = 'file.size',
+  'donors.gender' = 'donors.gender',
+  variant_class = 'variant_class',
+  file_access = 'file_access',
+}


### PR DESCRIPTION
**Description of changes**

pulls fields' display names from the gateway for:
- facet panel
- table

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
