### PR TITLE
🐛 resets to page 0 when filters change

### DIFF
--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -86,6 +86,10 @@ const useFileRepoPaginationState = () => {
     sort: DEFAULT_SORT,
   });
 
+  React.useEffect(() => {
+    resetCurrentPage();
+  }, [pagingState.pageSize]);
+
   const handlePagingStateChange = (state: typeof pagingState) => {
     setPagingState(state);
   };
@@ -97,7 +101,6 @@ const useFileRepoPaginationState = () => {
   const onPageSizeChange = (newPageSize: number) => {
     handlePagingStateChange({
       ...pagingState,
-      page: 0,
       pageSize: newPageSize,
     });
   };

--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -114,11 +114,18 @@ const useFileRepoPaginationState = () => {
     );
     handlePagingStateChange({ ...pagingState, sort });
   };
+  const resetCurrentPage = () => {
+    setPagingState({
+      ...pagingState,
+      page: 0,
+    });
+  };
   return {
     pagingState,
     onPageChange,
     onPageSizeChange,
     onSortedChange,
+    resetCurrentPage,
   };
 };
 
@@ -132,7 +139,11 @@ export default () => {
     onPageChange,
     onPageSizeChange,
     onSortedChange,
+    resetCurrentPage,
   } = useFileRepoPaginationState();
+  React.useEffect(() => {
+    resetCurrentPage();
+  }, [filters]);
 
   const offset = pagingState.pageSize * pagingState.page;
   const { data: records, loading = true } = useFileRepoTableQuery(
@@ -243,7 +254,7 @@ export default () => {
   const fileRepoEntries: FileRepositoryRecord[] = records
     ? records.file.hits.edges.map(({ node }) => ({
         objectId: node.object_id,
-        donorId: node.donors.hits.edges.map(edge => edge.node.donor_id).join(', '),
+        donorId: node.donors.hits.edges.map((edge) => edge.node.donor_id).join(', '),
         programId: node.study_id,
         dataType: node.data_type,
         experimentalStrategy: node.analysis.experiment.experimental_strategy,


### PR DESCRIPTION
**Description of changes**

when filters change, table should reset to first page

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
