### PR TITLE
filerepo facets smoother transitions

### DIFF
--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -235,7 +235,7 @@ export default () => {
 
   const [aggregations, setAggregations] = React.useState({});
 
-  const { data, loading = true } = useFileFacetQuery(filters, {
+  const { data, loading } = useFileFacetQuery(filters, {
     onCompleted: (data) => {
       setAggregations(data ? data.file.aggregations : {});
     },

--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -233,21 +233,13 @@ export default () => {
   const theme = useTheme();
   const { filters, setFilterFromFieldAndValue, replaceAllFilters } = useFiltersContext();
 
-  const { data, loading } = useFileFacetQuery(filters);
+  const [aggregations, setAggregations] = React.useState({});
 
-  const [aggregations, setAggregations] = React.useState(data ? data.file.aggregations : {});
-
-  const [isFacetLoading, setIsFacetLoading] = React.useState(true);
-
-  React.useEffect(() => {
-    if (loading) {
-      setIsFacetLoading(true);
-      return;
-    }
-
-    setAggregations(data ? data.file.aggregations : aggregations);
-    setIsFacetLoading(false);
-  }, [loading]);
+  const { data, loading = true } = useFileFacetQuery(filters, {
+    onCompleted: (data) => {
+      setAggregations(data ? data.file.aggregations : {});
+    },
+  });
 
   const clickHandler = (targetFacet: FacetDetails) => {
     const targetFacetPath = targetFacet.facetPath;
@@ -400,8 +392,8 @@ export default () => {
 
   return (
     <FacetContainer
-      // using css to fade and disable because FacetContainer uses over-flow which causes the DNAloader to scroll and not cover all facets
-      css={isFacetLoading ? facetContianerLoadingStyle : facetContainerDefaultStyle}
+      // using css to fade and disable because FacetContainer uses over-flow which causes the DNAloader to move with scroll and not cover all facets
+      css={loading ? facetContianerLoadingStyle : facetContainerDefaultStyle}
       theme={theme}
     >
       <SubMenu>

--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -189,7 +189,20 @@ export default () => {
   const { filters, setFilterFromFieldAndValue, replaceAllFilters } = useFiltersContext();
 
   const { data, loading } = useFileFacetQuery(filters);
-  const aggregations = data ? data.file.aggregations : {};
+
+  const [aggregations, setAggregations] = React.useState(data ? data.file.aggregations : {});
+
+  const [isFacetLoading, setIsFacetLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    if (loading) {
+      setIsFacetLoading(true);
+      return;
+    }
+
+    setAggregations(data ? data.file.aggregations : aggregations);
+    setIsFacetLoading(false);
+  }, [loading]);
 
   const clickHandler = (targetFacet: FacetDetails) => {
     const targetFacetPath = targetFacet.facetPath;
@@ -313,8 +326,21 @@ export default () => {
     ).toString();
   };
 
+  const facetContianerLoadingStyle = css`
+    opacity: 0.5;
+    pointer-events: 'none';
+  `;
+
+  const facetContainerDefaultStyle = css`
+    opacity: 1;
+    pointer-events: 'auto';
+  `;
   return (
-    <FacetContainer loading={loading} theme={theme}>
+    <FacetContainer
+      // using css to fade and disable because FacetContainer uses over-flow which causes the DNAloader to scroll and not cover all facets
+      css={isFacetLoading ? facetContianerLoadingStyle : facetContainerDefaultStyle}
+      theme={theme}
+    >
       <SubMenu>
         <FacetRow>
           <Typography


### PR DESCRIPTION
**Description of changes**

- keep facet aggregations in a state to render between filter change loads
- fade facet container and disable during loading 
    - DNALoader didn't disable and cover entire facet container, can still see container when you scroll down on it

**Type of Change**

- [ ] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
