### PR TITLE
Add error icons and notification banner to donor summary section

### DIFF
--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
@@ -74,7 +74,7 @@ export default ({
     fullyReleasedDonorsCount: 0,
     partiallyReleasedDonorsCount: 0,
     noReleaseDonorsCount: 0,
-    invalidDonorsCount: 0,
+    donorsInvalidWithCurrentDictionaryCount: 0,
   };
 
   const containerRef = createRef<HTMLDivElement>();
@@ -385,12 +385,7 @@ export default ({
             css={css`
               opacity: ${isTableLoading ? 0.5 : 1};
             `}
-            programDonorSummaryStats={{
-              ...programDonorSummaryStats,
-              invalidDonorsCount: programDonorSummaryEntries.filter(
-                (donor) => !donor.validWithCurrentDictionary,
-              ).length,
-            }}
+            programDonorSummaryStats={programDonorSummaryStats}
           />
         }
         noMargin={true}

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
@@ -74,20 +74,23 @@ export default ({
     fullyReleasedDonorsCount: 0,
     partiallyReleasedDonorsCount: 0,
     noReleaseDonorsCount: 0,
+    invalidDonorsCount: 0,
   };
 
   const containerRef = createRef<HTMLDivElement>();
   const checkmarkIcon = <Icon name="checkmark" fill="accent1_dimmed" width="12px" height="12px" />;
 
   const StatusColumnCell = ({ original }: { original: DonorSummaryRecord }) => {
-    return (
-      <CellContentCenter>
-        <StarIcon
-          fill={RELEASED_STATE_FILL_COLOURS[original.releaseStatus]}
-          outline={RELEASED_STATE_STROKE_COLOURS[original.releaseStatus]}
-        />
-      </CellContentCenter>
+    const theme = useTheme();
+    const displayIcon = original.validWithCurrentDictionary ? (
+      <StarIcon
+        fill={RELEASED_STATE_FILL_COLOURS[original.releaseStatus]}
+        outline={RELEASED_STATE_STROKE_COLOURS[original.releaseStatus]}
+      />
+    ) : (
+      <Icon name="warning" fill={theme.colors.error} width="16px" height="15px" />
     );
+    return <CellContentCenter>{displayIcon}</CellContentCenter>;
   };
 
   const PercentageCell = ({
@@ -356,7 +359,7 @@ export default ({
         const fields = sortRule.id.split(ID_SEPARATOR);
         const order = sortRule.desc ? 'desc' : 'asc';
         return accSorts.concat(
-          fields.map(field => ({
+          fields.map((field) => ({
             field: field as DonorSummaryEntrySortField,
             order: order as DonorSummaryEntrySortOrder,
           })),
@@ -382,7 +385,12 @@ export default ({
             css={css`
               opacity: ${isTableLoading ? 0.5 : 1};
             `}
-            programDonorSummaryStats={programDonorSummaryStats}
+            programDonorSummaryStats={{
+              ...programDonorSummaryStats,
+              invalidDonorsCount: programDonorSummaryEntries.filter(
+                (donor) => !donor.validWithCurrentDictionary,
+              ).length,
+            }}
           />
         }
         noMargin={true}

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTableStatArea.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTableStatArea.tsx
@@ -22,12 +22,15 @@ import Icon from 'uikit/Icon';
 import { DonorDataReleaseState, ProgramDonorReleaseStats } from './types';
 import { RELEASED_STATE_FILL_COLOURS, RELEASED_STATE_STROKE_COLOURS } from './common';
 import { StatArea as StatAreaDisplay } from '../../common';
+import { useTheme } from 'uikit/ThemeProvider';
+import { css } from '@emotion/core';
 
 const emptyProgramDonorSummaryStats: ProgramDonorReleaseStats = {
   registeredDonorsCount: 0,
   fullyReleasedDonorsCount: 0,
   noReleaseDonorsCount: 0,
   partiallyReleasedDonorsCount: 0,
+  invalidDonorsCount: 0,
 };
 
 const DonorStatsArea = ({
@@ -37,6 +40,7 @@ const DonorStatsArea = ({
   programDonorSummaryStats: ProgramDonorReleaseStats;
   className?: string;
 }) => {
+  const theme = useTheme();
   return (
     <StatAreaDisplay.Container className={className}>
       <StatAreaDisplay.Section>
@@ -70,6 +74,28 @@ const DonorStatsArea = ({
           {programDonorSummaryStats.noReleaseDonorsCount} with no released files
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
+      {programDonorSummaryStats.invalidDonorsCount > 0 && (
+        <StatAreaDisplay.Section>
+          <StatAreaDisplay.StatEntryContainer>
+            <Icon
+              name="warning"
+              fill={theme.colors.error}
+              width="16px"
+              height="15px"
+              css={css`
+                padding-right: 6px;
+              `}
+            />
+            <span
+              css={css`
+                color: ${theme.colors.error_dark};
+              `}
+            >
+              {programDonorSummaryStats.invalidDonorsCount} Invalid donors
+            </span>
+          </StatAreaDisplay.StatEntryContainer>
+        </StatAreaDisplay.Section>
+      )}
     </StatAreaDisplay.Container>
   );
 };

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTableStatArea.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTableStatArea.tsx
@@ -30,7 +30,7 @@ const emptyProgramDonorSummaryStats: ProgramDonorReleaseStats = {
   fullyReleasedDonorsCount: 0,
   noReleaseDonorsCount: 0,
   partiallyReleasedDonorsCount: 0,
-  invalidDonorsCount: 0,
+  donorsInvalidWithCurrentDictionaryCount: 0,
 };
 
 const DonorStatsArea = ({
@@ -74,7 +74,7 @@ const DonorStatsArea = ({
           {programDonorSummaryStats.noReleaseDonorsCount} with no released files
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
-      {programDonorSummaryStats.invalidDonorsCount > 0 && (
+      {programDonorSummaryStats.donorsInvalidWithCurrentDictionaryCount > 0 && (
         <StatAreaDisplay.Section>
           <StatAreaDisplay.StatEntryContainer>
             <Icon
@@ -91,7 +91,7 @@ const DonorStatsArea = ({
                 color: ${theme.colors.error_dark};
               `}
             >
-              {programDonorSummaryStats.invalidDonorsCount} Invalid donors
+              {programDonorSummaryStats.donorsInvalidWithCurrentDictionaryCount} Invalid donors
             </span>
           </StatAreaDisplay.StatEntryContainer>
         </StatAreaDisplay.Section>

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/InvalidDonorsNotification.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/InvalidDonorsNotification.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React from 'react';
+import { css } from '@emotion/core';
+import Link from 'uikit/Link';
+import Notification from 'uikit/notifications/Notification';
+import { getConfig } from 'global/config';
+import urljoin from 'url-join';
+import { DOCS_DICTIONARY_PATH } from 'global/constants/docSitePaths';
+import { useClinicalSubmissionSchemaVersion } from 'global/hooks/useClinicalSubmissionSchemaVersion';
+import pluralize from 'pluralize';
+
+export const InvalidDonorsNotification = ({ numInvalidDonors }: { numInvalidDonors: number }) => {
+  const { DOCS_URL_ROOT } = getConfig();
+  const latestDictionaryResponse = useClinicalSubmissionSchemaVersion();
+
+  const errorBody = (
+    <div
+      css={css`
+        padding: 8px 8px 8px 0px;
+      `}
+    >
+      {!latestDictionaryResponse.loading && (
+        <Link href={urljoin(DOCS_URL_ROOT, DOCS_DICTIONARY_PATH)} target="_blank">
+          Version {latestDictionaryResponse.data.clinicalSubmissionSchemaVersion} of the data
+          dictionary
+        </Link>
+      )}{' '}
+      was released and has made some donors invalid. All invalid donors, along with their released
+      files, will be revoked in the next release.
+    </div>
+  );
+
+  return (
+    <Notification
+      css={css`
+        margin-top: 10px;
+      `}
+      size="MD"
+      variant="ERROR"
+      title={`${pluralize('donor', numInvalidDonors, true)} ${pluralize(
+        'is',
+        numInvalidDonors,
+      )} invalid and will be revoked if not corrected.`}
+      content={errorBody}
+      interactionType={'NONE'}
+    />
+  );
+};

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/InvalidDonorsNotification.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/InvalidDonorsNotification.tsx
@@ -48,7 +48,7 @@ export const InvalidDonorsNotification = ({ numInvalidDonors }: { numInvalidDono
     </div>
   );
 
-  return (
+  return numInvalidDonors > 0 ? (
     <Notification
       css={css`
         margin-top: 10px;
@@ -62,5 +62,5 @@ export const InvalidDonorsNotification = ({ numInvalidDonors }: { numInvalidDono
       content={errorBody}
       interactionType={'NONE'}
     />
-  );
+  ) : null;
 };

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/gql/PROGRAM_DONOR_SUMMARY_QUERY.gql
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/gql/PROGRAM_DONOR_SUMMARY_QUERY.gql
@@ -36,5 +36,6 @@ query PROGRAM_DONOR_SUMMARY_QUERY(
     fullyReleasedDonorsCount
     partiallyReleasedDonorsCount
     noReleaseDonorsCount
+    donorsInvalidWithCurrentDictionaryCount
   }
 }

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/index.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/index.tsx
@@ -80,7 +80,7 @@ export default () => {
 
   // using the default query variables will get us all registered donors
   const {
-    data: { programDonorSummaryStats = undefined, programDonorSummaryEntries = [] } = {},
+    data: { programDonorSummaryStats = undefined } = {},
     loading: isCardLoading = true,
   } = useProgramDonorsSummaryQuery(
     programShortName,
@@ -94,12 +94,6 @@ export default () => {
 
   const isDonorSummaryEntriesEmpty =
     !programDonorSummaryStats || programDonorSummaryStats.registeredDonorsCount === 0;
-
-  const numInvalidDonors = programDonorSummaryEntries.filter(
-    (donor) => !donor.validWithCurrentDictionary,
-  ).length;
-
-  // todo: instead programDonorSummaryStats.invalidDonorsCount instead, once ready
 
   const CardTitle = () => (
     <Typography variant="default" component="span">
@@ -130,10 +124,12 @@ export default () => {
           <DownloadButtons />
         </Col>
       </Row>
-      {numInvalidDonors > 0 && (
+      {!isCardLoading && (
         <Row>
           <Col>
-            <InvalidDonorsNotification numInvalidDonors={numInvalidDonors} />
+            <InvalidDonorsNotification
+              numInvalidDonors={programDonorSummaryStats.donorsInvalidWithCurrentDictionaryCount}
+            />
           </Col>
         </Row>
       )}

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/index.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/index.tsx
@@ -35,6 +35,7 @@ import { useTimeout } from './common';
 import { css } from '@emotion/core';
 import { Row, Col } from 'react-grid-system';
 import DownloadButtons from './DownloadButtons';
+import { InvalidDonorsNotification } from './InvalidDonorsNotification';
 
 export const useProgramDonorsSummaryQuery = (
   programShortName: string,
@@ -79,7 +80,7 @@ export default () => {
 
   // using the default query variables will get us all registered donors
   const {
-    data: { programDonorSummaryStats = undefined } = {},
+    data: { programDonorSummaryStats = undefined, programDonorSummaryEntries = [] } = {},
     loading: isCardLoading = true,
   } = useProgramDonorsSummaryQuery(
     programShortName,
@@ -93,6 +94,12 @@ export default () => {
 
   const isDonorSummaryEntriesEmpty =
     !programDonorSummaryStats || programDonorSummaryStats.registeredDonorsCount === 0;
+
+  const numInvalidDonors = programDonorSummaryEntries.filter(
+    (donor) => !donor.validWithCurrentDictionary,
+  ).length;
+
+  // todo: instead programDonorSummaryStats.invalidDonorsCount instead, once ready
 
   const CardTitle = () => (
     <Typography variant="default" component="span">
@@ -123,6 +130,13 @@ export default () => {
           <DownloadButtons />
         </Col>
       </Row>
+      {numInvalidDonors > 0 && (
+        <Row>
+          <Col>
+            <InvalidDonorsNotification numInvalidDonors={numInvalidDonors} />
+          </Col>
+        </Row>
+      )}
       <DonorSummaryTable
         programShortName={programShortName}
         initialPages={initialPages}

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/types.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/types.tsx
@@ -43,7 +43,7 @@ export type ProgramDonorReleaseStats = {
   fullyReleasedDonorsCount: number;
   partiallyReleasedDonorsCount: number;
   noReleaseDonorsCount: number;
-  invalidDonorsCount: number;
+  donorsInvalidWithCurrentDictionaryCount: number;
 };
 
 export enum DonorDataReleaseState {

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/types.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/types.tsx
@@ -35,6 +35,7 @@ export type DonorSummaryRecord = {
   sangerVcsFailed: number;
   processingStatus: MolecularProcessingStatus;
   updatedAt: Date | String;
+  validWithCurrentDictionary: boolean;
 };
 
 export type ProgramDonorReleaseStats = {
@@ -42,6 +43,7 @@ export type ProgramDonorReleaseStats = {
   fullyReleasedDonorsCount: number;
   partiallyReleasedDonorsCount: number;
   noReleaseDonorsCount: number;
+  invalidDonorsCount: number;
 };
 
 export enum DonorDataReleaseState {


### PR DESCRIPTION
**Description of changes**
- adds type for the `validWithCurrentDictionary` that comes with each donor summary record,
uses it to display an error icon in the table
- also uses it to manually count the total invalid donors, but expecting that to come as a statistic later ( like the other statistics )

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
