### PR TITLE
🔥 1618 - reorder facets

### DIFF
--- a/components/pages/file-repository/FacetPanel/FILE_REPOSITORY_FACETS_QUERY.gql
+++ b/components/pages/file-repository/FacetPanel/FILE_REPOSITORY_FACETS_QUERY.gql
@@ -7,31 +7,13 @@ query FILE_REPOSITORY_FACETS_QUERY($filters: JSON) {
           doc_count
         }
       }
-      donors__gender {
-        buckets {
-          key
-          doc_count
-        }
-      }
       analysis__experiment__experimental_strategy {
         buckets {
           key
           doc_count
         }
       }
-      data_type {
-        buckets {
-          key
-          doc_count
-        }
-      }
       file_type {
-        buckets {
-          key
-          doc_count
-        }
-      }
-      analysis__variant_class {
         buckets {
           key
           doc_count

--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -82,54 +82,6 @@ const createPresetFacets = (
     esDocumentField: FileCentricDocumentField.study_id,
   },
   {
-    name: displayNames['donors.gender'],
-    facetPath: FileFacetPath.donors__gender,
-    variant: 'Basic',
-    esDocumentField: FileCentricDocumentField['donors.gender'],
-  },
-  {
-    name: displayNames['analysis.experiment.experimental_strategy'],
-    facetPath: FileFacetPath.analysis__experiment__experimental_strategy,
-    variant: 'Basic',
-    esDocumentField: FileCentricDocumentField['analysis.experiment.experimental_strategy'],
-  },
-  {
-    name: displayNames['data_type'],
-    facetPath: FileFacetPath.data_type,
-    variant: 'Basic',
-    esDocumentField: FileCentricDocumentField.data_type,
-  },
-  {
-    name: displayNames['file_type'],
-    facetPath: FileFacetPath.file_type,
-    variant: 'Basic',
-    esDocumentField: FileCentricDocumentField.file_type,
-  },
-  {
-    name: displayNames['analysis.variant_class'],
-    facetPath: FileFacetPath.analysis__variant_class,
-    variant: 'Basic',
-    esDocumentField: FileCentricDocumentField['analysis.variant_class'],
-  },
-  {
-    name: displayNames['file_access'],
-    facetPath: FileFacetPath.file_access,
-    variant: 'Basic',
-    esDocumentField: FileCentricDocumentField.file_access,
-  },
-  {
-    name: displayNames['data_category'],
-    facetPath: FileFacetPath.data_category,
-    variant: 'Basic',
-    esDocumentField: FileCentricDocumentField['data_category'],
-  },
-  {
-    name: displayNames['analysis_tools'],
-    facetPath: FileFacetPath.analysis_tools,
-    variant: 'Basic',
-    esDocumentField: FileCentricDocumentField['analysis_tools'],
-  },
-  {
     name: displayNames['donors.specimens.specimen_type'],
     facetPath: FileFacetPath.donors__specimens__specimen_type,
     variant: 'Basic',
@@ -142,10 +94,40 @@ const createPresetFacets = (
     esDocumentField: FileCentricDocumentField['donors.specimens.specimen_tissue_source'],
   },
   {
+    name: displayNames['analysis.experiment.experimental_strategy'],
+    facetPath: FileFacetPath.analysis__experiment__experimental_strategy,
+    variant: 'Basic',
+    esDocumentField: FileCentricDocumentField['analysis.experiment.experimental_strategy'],
+  },
+  {
+    name: displayNames['data_category'],
+    facetPath: FileFacetPath.data_category,
+    variant: 'Basic',
+    esDocumentField: FileCentricDocumentField['data_category'],
+  },
+  {
+    name: displayNames['file_type'],
+    facetPath: FileFacetPath.file_type,
+    variant: 'Basic',
+    esDocumentField: FileCentricDocumentField.file_type,
+  },
+  {
+    name: displayNames['file_access'],
+    facetPath: FileFacetPath.file_access,
+    variant: 'Basic',
+    esDocumentField: FileCentricDocumentField.file_access,
+  },
+  {
     name: displayNames['analysis.workflow.workflow_name'],
     facetPath: FileFacetPath.analysis__workflow__workflow_name,
     variant: 'Basic',
     esDocumentField: FileCentricDocumentField['analysis.workflow.workflow_name'],
+  },
+  {
+    name: displayNames['analysis_tools'],
+    facetPath: FileFacetPath.analysis_tools,
+    variant: 'Basic',
+    esDocumentField: FileCentricDocumentField['analysis_tools'],
   },
 ];
 

--- a/components/pages/file-repository/FacetPanel/types.ts
+++ b/components/pages/file-repository/FacetPanel/types.ts
@@ -4,11 +4,8 @@ import { FileCentricDocumentField } from '../types';
 
 export enum FileFacetPath {
   study_id = 'study_id',
-  donors__gender = 'donors__gender',
   analysis__experiment__experimental_strategy = 'analysis__experiment__experimental_strategy',
-  data_type = 'data_type',
   file_type = 'file_type',
-  analysis__variant_class = 'analysis__variant_class',
   file_access = 'file_access',
   data_category = 'data_category',
   analysis_tools = 'analysis_tools',
@@ -40,22 +37,28 @@ export type FileRepoFacetsQueryData = {
       [FileFacetPath.study_id]: {
         buckets: BucketAggregation[];
       };
-      [FileFacetPath.donors__gender]: {
-        buckets: BucketAggregation[];
-      };
       [FileFacetPath.analysis__experiment__experimental_strategy]: {
-        buckets: BucketAggregation[];
-      };
-      [FileFacetPath.data_type]: {
         buckets: BucketAggregation[];
       };
       [FileFacetPath.file_type]: {
         buckets: BucketAggregation[];
       };
-      [FileFacetPath.analysis__variant_class]: {
+      [FileFacetPath.file_access]: {
         buckets: BucketAggregation[];
       };
-      [FileFacetPath.file_access]: {
+      [FileFacetPath.data_category]: {
+        buckets: BucketAggregation[];
+      };
+      [FileFacetPath.analysis_tools]: {
+        buckets: BucketAggregation[];
+      };
+      [FileFacetPath.donors__specimens__specimen_type]: {
+        buckets: BucketAggregation[];
+      };
+      [FileFacetPath.donors__specimens__specimen_tissue_source]: {
+        buckets: BucketAggregation[];
+      };
+      [FileFacetPath.analysis__workflow__workflow_name]: {
         buckets: BucketAggregation[];
       };
     };


### PR DESCRIPTION
**Description of changes**

Reorders facet panel, removes `gender`, `data_type` and `variant_class`
- removes those types from agg typing
- left the deleted fields in the `FileCentricDocumentField` type

**Type of Change**

- [ ] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [x] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
