### PR TITLE
🐛 1357 - Set timeout for global loader on logout to home

### DIFF
--- a/components/pages/Homepage/index.tsx
+++ b/components/pages/Homepage/index.tsx
@@ -52,6 +52,9 @@ import {
   DOCS_DATA_DOWNLOAD_PAGE,
 } from 'global/constants/docSitePaths';
 import { useFileRepoStatsBarQuery } from '../file-repository/StatsCard';
+import { useGlobalLoadingState } from 'components/ApplicationRoot';
+import useAuthContext from 'global/hooks/useAuthContext';
+import { sleep } from 'global/utils/common';
 
 const SeparationLine: React.ComponentType<{}> = () => {
   const theme = useTheme();
@@ -99,7 +102,12 @@ export default function Homepage() {
   const { FEATURE_REPOSITORY_ENABLED, FEATURE_LANDING_PAGE_STATS_ENABLED } = getConfig();
 
   const { data: stats, loading } = useFileRepoStatsBarQuery();
+  const { isLoading: isLoaderShown, setLoading: setIsLoaderShown } = useGlobalLoadingState();
 
+  const { isLoggingOut } = useAuthContext();
+  if (isLoggingOut && isLoaderShown) {
+    sleep(1000).then(() => setIsLoaderShown(false));
+  }
   return (
     <DefaultLayout>
       <HeroDiv>

--- a/components/pages/Homepage/index.tsx
+++ b/components/pages/Homepage/index.tsx
@@ -52,9 +52,6 @@ import {
   DOCS_DATA_DOWNLOAD_PAGE,
 } from 'global/constants/docSitePaths';
 import { useFileRepoStatsBarQuery } from '../file-repository/StatsCard';
-import { useGlobalLoadingState } from 'components/ApplicationRoot';
-import useAuthContext from 'global/hooks/useAuthContext';
-import { sleep } from 'global/utils/common';
 
 const SeparationLine: React.ComponentType<{}> = () => {
   const theme = useTheme();
@@ -102,12 +99,7 @@ export default function Homepage() {
   const { FEATURE_REPOSITORY_ENABLED, FEATURE_LANDING_PAGE_STATS_ENABLED } = getConfig();
 
   const { data: stats, loading } = useFileRepoStatsBarQuery();
-  const { isLoading: isLoaderShown, setLoading: setIsLoaderShown } = useGlobalLoadingState();
 
-  const { isLoggingOut } = useAuthContext();
-  if (isLoggingOut && isLoaderShown) {
-    sleep(1000).then(() => setIsLoaderShown(false));
-  }
   return (
     <DefaultLayout>
       <HeroDiv>

--- a/global/hooks/useAuthContext.tsx
+++ b/global/hooks/useAuthContext.tsx
@@ -128,12 +128,12 @@ export function AuthProvider({
       method: 'GET',
       mode: 'cors',
     })
-      .then(res => res.text())
-      .then(egoToken => {
+      .then((res) => res.text())
+      .then((egoToken) => {
         Cookies.set(EGO_JWT_KEY, egoToken);
         return egoToken;
       })
-      .catch(err => {
+      .catch((err) => {
         console.warn('err: ', err);
         throw err;
       });

--- a/global/hooks/useProgramCheckEffect.tsx
+++ b/global/hooks/useProgramCheckEffect.tsx
@@ -35,21 +35,22 @@ export const useProgramCheckEffect = () => {
       shortName: shortName,
     },
   });
-
   const { setLoading: setLoaderShown, isLoading: isLoaderShown } = useGlobalLoadingState();
   const { isLoggingOut } = useAuthContext();
 
   useEffect(() => {
-    if (!program && !isLoaderShown) {
-      setLoaderShown(true);
-    }
-    if (!loadingQuery) {
-      if (!program && !isLoggingOut) {
-        const err = new Error('Program not found') as Error & { statusCode?: number };
-        err[ERROR_STATUS_KEY] = 404;
-        throw err;
-      } else if (isLoaderShown) {
-        sleep(1200).then(() => setLoaderShown(false));
+    if (!isLoggingOut) {
+      if (!program && !isLoaderShown) {
+        setLoaderShown(true);
+      }
+      if (!loadingQuery) {
+        if (!program) {
+          const err = new Error('Program not found') as Error & { statusCode?: number };
+          err[ERROR_STATUS_KEY] = 404;
+          throw err;
+        } else if (isLoaderShown) {
+          sleep(1200).then(() => setLoaderShown(false));
+        }
       }
     }
   }, [program, loadingQuery]);

--- a/pages/submission/program/[shortName]/dashboard.tsx
+++ b/pages/submission/program/[shortName]/dashboard.tsx
@@ -35,7 +35,7 @@ export default createPage({
     );
   },
   startWithGlobalLoader: true,
-})(props => {
+})((props) => {
   useProgramCheckEffect();
   return <ProgramDashboard {...props} />;
 });


### PR DESCRIPTION
**Description of changes**

Set timeout to remove global loader on homepage when logging out, prevent sporadic endless loading state

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
