### PR TITLE
unify onMount hooks, set first render after router replace

### DIFF
--- a/global/hooks/useUrlParamState.ts
+++ b/global/hooks/useUrlParamState.ts
@@ -61,15 +61,11 @@ export const useHook = <T>(
   const [firstRender, setFirstRender] = React.useState(true);
 
   React.useEffect(() => {
-    setFirstRender(false);
-  }, []);
-
-  React.useEffect(() => {
     const newPath = `${router.asPath.split('?')[0]}?${new window.URLSearchParams({
       [key]: serialize(initialValue),
       ...currentQuery,
     }).toString()}`;
-    router.replace(router.pathname, newPath);
+    router.replace(router.pathname, newPath).then(() => setFirstRender(false));
   }, []);
 
   const setUrlState = (value: T) => {
@@ -88,6 +84,7 @@ export const useHook = <T>(
     const sanitized = getSanitizedValue(v);
     return deSerialize(sanitized);
   };
+
   return [firstRender ? initialValue : deserializeValue(currentQuery[key]), setUrlState] as [
     T,
     typeof setUrlState,


### PR DESCRIPTION
**Description of changes**

setting first render state without waiting for new url causing undefined in query paths

- move `setFirstRender` into onMount hook
- wait for router.replace to set first render state

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
