### PR TITLE
Server-side render of homepage stats

### DIFF
--- a/global/utils/pages/types.tsx
+++ b/global/utils/pages/types.tsx
@@ -43,7 +43,12 @@ export type PageConfigProps = {
   getInitialProps: (args: GetInitialPropsContextWithEgo) => Promise<any>;
   getGqlQueriesToPrefetch: (
     args: GetInitialPropsContextWithEgo,
-  ) => Promise<Array<{ query: any; variables?: { [key: string]: any } }>>;
+  ) => Promise<
+    Array<{
+      query: string; // The gql query string
+      variables?: { [key: string]: any };
+    }>
+  >;
   startWithGlobalLoader: boolean;
 };
 export type PageWithConfig = PageConfigProps & React.ComponentType<any>;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,10 +19,14 @@
 
 import HomePage from '../components/pages/Homepage';
 import { createPage } from 'global/utils/pages';
+import STATS_BAR from '../components/pages/file-repository/StatsCard/STATS_BAR.gql';
 
 const landingPage = HomePage;
 
 export default createPage({
   isPublic: true,
+  getGqlQueriesToPrefetch: async () => {
+    return [{ query: STATS_BAR }];
+  },
   getInitialProps: async () => ({}),
 })(landingPage);


### PR DESCRIPTION
**Description of changes**

used `getGqlQueriesToPrefetch` to cache the statistics for the homepage render

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
