### PR TITLE
change release_stage facet to filter itself

### DIFF
--- a/components/pages/file-repository/FacetPanel/FILE_REPOSITORY_FACETS_QUERY.gql
+++ b/components/pages/file-repository/FacetPanel/FILE_REPOSITORY_FACETS_QUERY.gql
@@ -1,16 +1,20 @@
 query FILE_REPOSITORY_FACETS_QUERY($filters: JSON) {
+  selfFiltered: file {
+    aggregations(filters: $filters, include_missing: false, aggregations_filter_themselves: true) {
+      release_stage {
+        buckets {
+          doc_count
+          key
+        }
+      }
+    }
+  }
   file {
     aggregations(filters: $filters, include_missing: true, aggregations_filter_themselves: false) {
       study_id {
         buckets {
           key
           doc_count
-        }
-      }
-      release_stage {
-        buckets {
-          doc_count
-          key
         }
       }
       analysis__experiment__experimental_strategy {

--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -259,7 +259,8 @@ export default () => {
 
   const { data, loading } = useFileFacetQuery(filters, {
     onCompleted: (data) => {
-      setAggregations(data ? data.file.aggregations : {});
+      const aggregations = { ...data?.file?.aggregations, ...data?.selfFiltered?.aggregations };
+      setAggregations(aggregations ? aggregations : {});
     },
   });
 


### PR DESCRIPTION
**Description of changes**

The release_stage facet needs to operate as filtering itself from server side filters, but not from client side filters.

Files are filtered by permissions server side.
In filtering itself, a user cannot select multiple release stages
eg. user selected `release_stage` `PUBLIC` and `study_id` `DASH-CA`, a user **cannot** then select another release stage as the facet has been filtered down to `PUBLIC`
```
{
  "filters":{
  "content": [
    {
      "content": {
        "field": "study_id",
        "value": "DASH-CA"
      },
      "op": "in"
    }, {
      "content": {
        "field": "release_stage",
        "value": "ASSOCIATE_PROGRAMS"
      },
      "op": "in"
    }
  ],
  "op": "and"
}
}
```

The fix here is to do a second query, with no client filters applied, which filters itself based on server side filters.
This query,  `FILE_REPOSITORY_PERMITTED_RELEASE_STAGES`, will return the release stages which are permitted.
Then filter to the permitted values.

The downside is that some reported numbers are present client side before being filtered out.
eg. if a user only has PUBLIC access, there may be ASSOCIATE file number present before filtered out.
This is why there were empty data in tables, because our table queries for the actual data is filtered properly before it's returned to client.


**Type of Change**

- [ ] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Matches design:

  - component sizes, spacing, and styles
  - font size, weight, colour
  - spelling has been double checked

- [ ] New uikit components have Storybook stories
- [ ] Feature is minimally responsive.
- [ ] Add copyrights to new files
- [ ] Manual testing of UI feature.
- [ ] Selenium test is completed and passing.
