### PR TITLE
remove additional token state

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -91,7 +91,7 @@ const getUserRole = (egoJwt, permissions) => {
 export default function Navbar({ hideLinks = false, disableLogoLink = false }) {
   const screenClass = useScreenClass();
   const { EGO_URL, FEATURE_REPOSITORY_ENABLED } = getConfig();
-  const { token: egoJwt, logOut, data: userModel, permissions } = useAuthContext();
+  const { egoJwt, logOut, data: userModel, permissions } = useAuthContext();
   const canAccessSubmission = React.useMemo(() => {
     return !!egoJwt && (canReadSomeProgram(permissions) || isRdpcMember(permissions));
   }, [egoJwt]);

--- a/components/pages/file-entity/index.tsx
+++ b/components/pages/file-entity/index.tsx
@@ -35,7 +35,7 @@ import { FileAccessState } from './types';
 
 const FileEntity = ({ fileId }) => {
   const { programShortName, access, size, data, loading: fileLoading } = useEntityData({ fileId });
-  const { token: egoJwt } = useAuthContext();
+  const { egoJwt } = useAuthContext();
   const { data: userProfile, loading: profileLoading } = useQuery(USER_PROFILE);
 
   const loading = profileLoading || fileLoading;

--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -228,7 +228,7 @@ const useIdSearchQuery = (
 // encapsulate conditional release stage facet logic
 const getReleaseStageFacet = (presetFacets: FacetDetails[], commonFacetProps) => {
   const { FEATURE_ACCESS_FACET_ENABLED } = getConfig();
-  const { token: egoJwt } = useAuthContext();
+  const { egoJwt } = useAuthContext();
 
   if (FEATURE_ACCESS_FACET_ENABLED && !!egoJwt) {
     const facet = presetFacets.find((f) => f.facetPath === FileFacetPath.release_stage);

--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -140,7 +140,7 @@ const useFileRepoPaginationState = () => {
 export default () => {
   const { FEATURE_FILE_ENTITY_ENABLED } = getConfig();
 
-  const { token } = useAuthContext();
+  const { egoJwt } = useAuthContext();
   const { filters } = useFiltersContext();
   const theme = useTheme();
 
@@ -173,8 +173,8 @@ export default () => {
   };
 
   const getDownloadStatus = (isDownloadable: boolean) => {
-    const canUserDownload = token && isDownloadable;
-    const toolTipText = token
+    const canUserDownload = egoJwt && isDownloadable;
+    const toolTipText = egoJwt
       ? isDownloadable
         ? 'Download file'
         : 'You do not have permission to download this file'

--- a/components/pages/submission-system/SideMenu.tsx
+++ b/components/pages/submission-system/SideMenu.tsx
@@ -111,7 +111,7 @@ type SampleRegistrationQueryResponse = {
 
 const LinksToProgram = (props: { program: SideMenuProgram; isCurrentlyViewed: boolean }) => {
   const pageContext = usePageContext();
-  const { token, permissions } = useAuthContext();
+  const { egoJwt, permissions } = useAuthContext();
   const { data } = useQuery<ClinicalSubmissionQueryResponse>(SIDE_MENU_CLINICAL_SUBMISSION_STATE, {
     variables: {
       programShortName: props.program.shortName,
@@ -141,22 +141,22 @@ const LinksToProgram = (props: { program: SideMenuProgram; isCurrentlyViewed: bo
 
   const canSeeCollaboratorView = React.useMemo(() => {
     return (
-      token &&
+      egoJwt &&
       !isCollaborator({
         permissions,
         programId: props.program.shortName,
       })
     );
-  }, [token]);
+  }, [egoJwt]);
   const canWriteToProgram = React.useMemo(() => {
     return (
-      token &&
+      egoJwt &&
       canWriteProgram({
         permissions,
         programId: props.program.shortName,
       })
     );
-  }, [token]);
+  }, [egoJwt]);
 
   return (
     <div>
@@ -275,10 +275,10 @@ const MultiProgramsSection = ({ programs }: { programs: Array<SideMenuProgram> }
   const { activeItem: activeProgramIndex, toggleItem: toggleProgramIndex } = useToggledSelectState(
     currentViewingProgramIndex,
   );
-  const { token, permissions } = useAuthContext();
+  const { egoJwt, permissions } = useAuthContext();
   const canSeeAllPrograms = React.useMemo(() => {
-    return token && isDccMember(permissions);
-  }, [token]);
+    return egoJwt && isDccMember(permissions);
+  }, [egoJwt]);
 
   return (
     <>
@@ -332,10 +332,10 @@ export default function SideMenu() {
   const { activeItem, toggleItem } = useToggledSelectState(isInProgramSection ? 1 : 0);
   const { data: { programs } = { programs: null }, loading } = useQuery(SIDE_MENU_PROGRAM_LIST);
 
-  const { data: egoTokenData, token, permissions } = useAuthContext();
+  const { data: egoTokenData, egoJwt, permissions } = useAuthContext();
 
-  const isDcc = React.useMemo(() => (token ? isDccMember(permissions) : false), [token]);
-  const isRdpc = React.useMemo(() => (token ? isRdpcMember(permissions) : false), [token]);
+  const isDcc = React.useMemo(() => (egoJwt ? isDccMember(permissions) : false), [egoJwt]);
+  const isRdpc = React.useMemo(() => (egoJwt ? isRdpcMember(permissions) : false), [egoJwt]);
 
   const canOnlyAccessOneProgram = programs && programs.length === 1 && !isDcc;
   const canSeeRdpcs = isDcc;

--- a/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
+++ b/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
@@ -119,12 +119,12 @@ export default ({
   submissionData?: React.ComponentProps<typeof SubmissionInfoArea>;
 }) => {
   const { shortName: programShortName } = usePageQuery<{ shortName: string }>();
-  const { token, permissions } = useAuthContext();
+  const { egoJwt, permissions } = useAuthContext();
   const isDiffPreview = React.useMemo(
     () =>
       (isDccMember(permissions) || isDataSubmitter({ permissions, programId: programShortName })) &&
       isPendingApproval,
-    [token, isPendingApproval],
+    [egoJwt, isPendingApproval],
   );
   const theme = useTheme();
   const { records, stats, dataWarnings } = file;

--- a/components/pages/submission-system/program-clinical-submission/Header.tsx
+++ b/components/pages/submission-system/program-clinical-submission/Header.tsx
@@ -55,8 +55,8 @@ export default ({
   isPendingApproval: boolean;
   submissionVersion: string;
 }) => {
-  const { token, permissions } = useAuthContext();
-  const isDcc = React.useMemo(() => isDccMember(permissions), [token]);
+  const { egoJwt, permissions } = useAuthContext();
+  const isDcc = React.useMemo(() => isDccMember(permissions), [egoJwt]);
   const { isModalShown, getUserConfirmation, modalProps } = useUserConfirmationModalState();
   const [loaderShown, setLoaderShown] = React.useState(false);
   const {
@@ -138,7 +138,7 @@ export default ({
       try {
         await approveClinicalSubmission();
 
-        updateClinicalSubmissionQuery(previous => ({
+        updateClinicalSubmissionQuery((previous) => ({
           ...previous,
           clinicalSubmissions: placeholderClinicalSubmissionQueryData(programShortName)
             .clinicalSubmissions,

--- a/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ProgramWorkspaceStatus/index.tsx
@@ -50,14 +50,14 @@ const ConditionalLink: React.ComponentType<{
 
 export default function ProgramWorkplaceStatus() {
   const { shortName: programShortName } = usePageQuery<{ shortName: string }>();
-  const { token, permissions } = useAuthContext();
+  const { egoJwt, permissions } = useAuthContext();
 
   const canViewLinks = React.useMemo(() => {
     return !isCollaborator({
       permissions,
       programId: programShortName,
     });
-  }, [token]);
+  }, [egoJwt]);
 
   return (
     <DashboardCard cardHeight="170px">

--- a/components/pages/submission-system/program-management/ManageProgramTabs.tsx
+++ b/components/pages/submission-system/program-management/ManageProgramTabs.tsx
@@ -59,7 +59,7 @@ const createUserInput = ({
 /* *************************************** *
  * Reshape form data for gql input
  * *************************************** */
-const createUpdateProgramInput = formData => ({
+const createUpdateProgramInput = (formData) => ({
   name: formData.programName,
   description: formData.description,
   commitmentDonors: parseInt(formData.commitmentLevel),
@@ -90,8 +90,8 @@ const useTabState = () => {
     USERS: 'users' as TabValue,
   };
   const [activeTab, setActiveTab] = useUrlParamState('activeTab', TABS.USERS, {
-    serialize: v => v,
-    deSerialize: v => v as TabValue,
+    serialize: (v) => v,
+    deSerialize: (v) => v as TabValue,
   });
 
   return { activeTab, setActiveTab, TABS } as {
@@ -102,8 +102,8 @@ const useTabState = () => {
 };
 
 export default () => {
-  const { token, permissions } = useAuthContext();
-  const isDcc = React.useMemo(() => isDccMember(permissions), [token]);
+  const { egoJwt, permissions } = useAuthContext();
+  const isDcc = React.useMemo(() => isDccMember(permissions), [egoJwt]);
 
   const { shortName: programShortName } = usePageQuery();
 
@@ -124,7 +124,7 @@ export default () => {
   const [triggerInvite] = useMutation(INVITE_USER_MUTATION);
 
   const [sendUpdateProgram] = useMutation(UPDATE_PROGRAM_MUTATION);
-  const onSubmit = async data => {
+  const onSubmit = async (data) => {
     try {
       await sendUpdateProgram({
         variables: {
@@ -139,7 +139,7 @@ export default () => {
     }
   };
 
-  const onAddUserSubmit = async validData => {
+  const onAddUserSubmit = async (validData) => {
     // Close modal on submit. Toasts after completion and refetch will indicate completion.
     // TODO: Some sort of indicator that data is being sent
     setShowModal(false);

--- a/components/pages/submission-system/programs/index.tsx
+++ b/components/pages/submission-system/programs/index.tsx
@@ -45,7 +45,7 @@ import PROGRAMS_USERS_QUERY from './PROGRAMS_USERS_QUERY.gql';
 import DnaLoader from 'uikit/DnaLoader';
 import get from 'lodash/get';
 
-const TableFilterInput = props => (
+const TableFilterInput = (props) => (
   <Input
     aria-label="tableFilter"
     preset={INPUT_PRESETS.SEARCH}
@@ -67,14 +67,18 @@ export default function Programs({ authorizedPrograms = [] }: any) {
   );
 
   if (programsWithUsers.length > 0) {
-    programs.forEach(p => {
-      const users = get(programsWithUsers.find(pp => p.shortName == pp.shortName), 'users', []);
+    programs.forEach((p) => {
+      const users = get(
+        programsWithUsers.find((pp) => p.shortName == pp.shortName),
+        'users',
+        [],
+      );
       p.administrators = filter(users, { role: 'ADMIN' });
     });
   }
 
-  const { token, permissions } = useAuthContext();
-  const canCreate = React.useMemo(() => token && isDccMember(permissions), [token]);
+  const { egoJwt, permissions } = useAuthContext();
+  const canCreate = React.useMemo(() => egoJwt && isDccMember(permissions), [egoJwt]);
   const sortedPrograms = orderBy(programs, 'name');
   const router = useRouter();
   const handleProgramUsersClick = ({ program }) => {

--- a/global/hooks/useAuthContext.tsx
+++ b/global/hooks/useAuthContext.tsx
@@ -28,7 +28,7 @@ import urlJoin from 'url-join';
 import refreshJwt from 'global/utils/refreshJwt';
 
 type T_AuthContext = {
-  token?: string;
+  egoJwt?: string;
   logOut: (config?: { toRoot?: boolean }) => void;
   updateToken: () => Promise<string | void>;
   data: ReturnType<typeof decodeToken> | null;
@@ -38,7 +38,7 @@ type T_AuthContext = {
 };
 
 const AuthContext = React.createContext<T_AuthContext>({
-  token: undefined,
+  egoJwt: undefined,
   logOut: () => {},
   updateToken: async () => {},
   data: null,
@@ -60,8 +60,6 @@ export function AuthProvider({
     EGO_API_ROOT,
     `/api/oauth/update-ego-token?client_id=${EGO_CLIENT_ID}`,
   );
-
-  const token = egoJwt;
 
   const permissions = getPermissionsFromToken(egoJwt);
 
@@ -96,7 +94,7 @@ export function AuthProvider({
       headers: { ...((options && options.headers) || {}), authorization: `Bearer ${egoJwt || ''}` },
     };
 
-    if (token && !isValidJwt(token)) {
+    if (egoJwt && !isValidJwt(egoJwt)) {
       const newJwt = (await refreshJwt()) as string;
       if (isValidJwt(newJwt)) {
         setToken(newJwt);
@@ -136,7 +134,7 @@ export function AuthProvider({
   };
 
   const authData = {
-    token: egoJwt,
+    egoJwt,
     logOut,
     data: egoJwt ? decodeToken(egoJwt || '') : null,
     updateToken,


### PR DESCRIPTION
**Description of changes**

Auth Provider had both token state and a token prop.
This causes a conflict when a new token comes from `_app`
Removed this extra state.

@anncatton I believe you worked on this section last, so please take a look in case I've overlooked something.
In particular regarding refreshed JWTs vs initial.
I've tested it locally and it seems to work. Logging/logging out is always combined with routing to a new page so `_app` re-renders and passes down the most recent `egoJwt`

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [x] Connected ticket to PR
