### PR TITLE
💄 add commas to large numbers

### DIFF
--- a/components/pages/file-repository/FileTable/TsvDownloadButton.tsx
+++ b/components/pages/file-repository/FileTable/TsvDownloadButton.tsx
@@ -58,7 +58,9 @@ export default ({
     ...(!!selectedFilesCount
       ? [
           {
-            display: `${pluralize('file', selectedFilesCount, true)} selected`,
+            display: `${selectedFilesCount.toLocaleString()} ${
+              pluralize('file', selectedFilesCount)
+            } selected`,
             value: DownloadOptionValues.ALL_FILES,
             css: css`
               color: ${theme.colors.secondary_dark};

--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -363,7 +363,9 @@ export default () => {
               </Typography>
               <Typography variant="data" color={theme.colors.secondary_dark}>
                 {!!selectedRowsCount &&
-                  ` (${selectedRowsCount} ${pluralize('file', selectedRowsCount)} selected)`}
+                  ` (${selectedRowsCount.toLocaleString()} ${
+                    pluralize('file', selectedRowsCount)
+                  } selected)`}
               </Typography>
             </div>
           </div>

--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -359,7 +359,7 @@ export default () => {
           >
             <div>
               <Typography variant="data" color="grey">
-                {`${startRowDisplay}-${endRowDisplay} of ${pluralize('file', totalEntries, true)}`}
+                {`${startRowDisplay.toLocaleString()}-${endRowDisplay.toLocaleString()} of ${totalEntries.toLocaleString()} ${pluralize('file', totalEntries)}`}
               </Typography>
               <Typography variant="data" color={theme.colors.secondary_dark}>
                 {!!selectedRowsCount &&

--- a/components/pages/file-repository/StatsCard/StatItem.tsx
+++ b/components/pages/file-repository/StatsCard/StatItem.tsx
@@ -40,7 +40,7 @@ const StatItem = ({ iconName, statType, count, loading = false }: StatItemProps)
   const displayStat =
     statType === 'fileSize'
       ? `${filesize(count)}`
-      : `${count} ${capitalize(pluralize(statType, count))}`;
+      : `${count.toLocaleString()} ${capitalize(pluralize(statType, count))}`;
 
   return (
     <Typography

--- a/components/pages/file-repository/charts/SimpleBarChart/index.tsx
+++ b/components/pages/file-repository/charts/SimpleBarChart/index.tsx
@@ -122,7 +122,7 @@ const YAxis = ({ max, theme }) => {
           `}
           color={theme.colors.primary}
         >
-          {max}
+          {max.toLocaleString()}
         </AxisText>
         <br />
         <AxisText color={theme.colors.primary}>0</AxisText>

--- a/components/pages/file-repository/charts/SimpleBarChart/index.tsx
+++ b/components/pages/file-repository/charts/SimpleBarChart/index.tsx
@@ -204,7 +204,7 @@ const SimpleBarChart: React.ComponentType<SimpleBarChartProps> = ({
                   <div>
                     <span>{capitalize(category)}</span>
                     <br />
-                    <span>{`${count} ${pluralize('file', count)}`}</span>
+                    <span>{`${count.toLocaleString()} ${pluralize('file', count)}`}</span>
                   </div>
                 }
               >

--- a/components/pages/submission-system/common.tsx
+++ b/components/pages/submission-system/common.tsx
@@ -228,7 +228,7 @@ export const Pipeline = (stats: PipelineStats) => {
 
   const pipeStats = renderableStats.map((stat) => (
     <Pipe.Item key={stat} fill={getBackgroundColour(stat as keyof PipelineStats)}>
-      {stats[stat]}
+      {stats[stat].toLocaleString()}
     </Pipe.Item>
   ));
   return <Pipe>{pipeStats}</Pipe>;

--- a/components/pages/submission-system/donor/ClinicalTimeline/index.tsx
+++ b/components/pages/submission-system/donor/ClinicalTimeline/index.tsx
@@ -60,7 +60,7 @@ const renderSelectedDataRow = (selectedData, selectedSamples) => {
         </Col>
         <Col>
           <Typography variant="navigation">
-            Samples from this Specimen ({selectedSamples.length})
+            Samples from this Specimen ({selectedSamples.length.toLocaleString()})
           </Typography>
           <Samples samples={selectedSamples} />
         </Col>

--- a/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
+++ b/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
@@ -85,19 +85,19 @@ const StatsArea = ({
       <StatAreaDisplay.Section faded={!isSubmissionValidated}>
         <StatAreaDisplay.StatEntryContainer>
           <StatAreaDisplay.StarIcon fill={FILE_STATE_COLORS.UPDATED} />
-          {isSubmissionValidated && fileStat.updateCount} Updated
+          {isSubmissionValidated && fileStat.updateCount.toLocaleString()} Updated
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
       <StatAreaDisplay.Section faded={!isSubmissionValidated}>
         <StatAreaDisplay.StatEntryContainer>
           <StatAreaDisplay.StarIcon fill={FILE_STATE_COLORS.NEW} />
-          {isSubmissionValidated && fileStat.newCount} New
+          {isSubmissionValidated && fileStat.newCount.toLocaleString()} New
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
       <StatAreaDisplay.Section faded={!isSubmissionValidated}>
         <StatAreaDisplay.StatEntryContainer>
           <StatAreaDisplay.StarIcon fill={FILE_STATE_COLORS.NONE} />
-          {isSubmissionValidated && fileStat.noUpdateCount} No Update
+          {isSubmissionValidated && fileStat.noUpdateCount.toLocaleString()} No Update
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
     </StatAreaDisplay.Container>

--- a/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
+++ b/components/pages/submission-system/program-clinical-submission/FilesNavigator/FileRecordTable.tsx
@@ -22,6 +22,7 @@ import Table, { TableColumnConfig } from 'uikit/Table';
 import orderBy from 'lodash/orderBy';
 import { css } from 'uikit';
 import Icon from 'uikit/Icon';
+import pluralize from 'pluralize';
 import {
   DataTableStarIcon,
   StatArea as StatAreaDisplay,
@@ -70,15 +71,15 @@ const StatsArea = ({
 }) => {
   return (
     <StatAreaDisplay.Container>
-      <StatAreaDisplay.Section>{total} Total</StatAreaDisplay.Section>
+      <StatAreaDisplay.Section>{total.toLocaleString()} Total</StatAreaDisplay.Section>
       <StatAreaDisplay.Section faded={!isSubmissionValidated}>
         <Icon name="chevron_right" fill="grey_1" width="8px" />
       </StatAreaDisplay.Section>
       <StatAreaDisplay.Section faded={!isSubmissionValidated}>
         <StatAreaDisplay.StatEntryContainer>
           <StatAreaDisplay.StarIcon fill={FILE_STATE_COLORS.ERROR} />
-          {isSubmissionValidated && fileStat.errorCount}{' '}
-          {fileStat.errorCount > 1 ? 'Errors' : 'Error'}
+          {isSubmissionValidated && fileStat.errorCount.toLocaleString()}{' '}
+          {pluralize('Error', fileStat.errorCount)}
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
       <StatAreaDisplay.Section faded={!isSubmissionValidated}>

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -500,7 +500,7 @@ export default () => {
         >
           <ErrorNotification
             level={NOTIFICATION_VARIANTS.ERROR}
-            title={`${allDataErrors.length} error(s) found in submission workspace`}
+            title={`${allDataErrors.length.toLocaleString()} error(s) found in submission workspace`}
             subtitle="Your submission cannot yet be signed off. Please correct the following errors and reupload the corresponding files."
             errors={allDataErrors.map(toDisplayError)}
             columnConfig={[
@@ -523,7 +523,7 @@ export default () => {
         >
           <ErrorNotification
             level={NOTIFICATION_VARIANTS.WARNING}
-            title={`${allDataWarnings.length} warning(s) found in submission workspace`}
+            title={`${allDataWarnings.length.toLocaleString()} warning(s) found in submission workspace`}
             subtitle="Your submission has the following warnings, check them to make sure the changes are as intended."
             errors={allDataWarnings.map(toDisplayError)}
             columnConfig={[

--- a/components/pages/submission-system/program-clinical-submission/PageContent.tsx
+++ b/components/pages/submission-system/program-clinical-submission/PageContent.tsx
@@ -485,7 +485,7 @@ export default () => {
           variant="ERROR"
           interactionType="CLOSE"
           title={`${fileNames.length} of ${
-            (currentFileList.fileList || []).length
+            (currentFileList.fileList || []).length.toLocaleString()
           } files failed to upload: ${fileNames.join(', ')}`}
           content={message}
           onInteraction={onErrorClose(i)}

--- a/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
@@ -371,7 +371,7 @@ const LineChart = ({
               x={xCoordinate}
               y={yCoordinate}
             >
-              {parseFloat(labelStr).toFixed(precision)}
+              {parseFloat(labelStr).toFixed(precision).toLocaleString()}
             </text>
           );
         })}

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTableStatArea.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTableStatArea.tsx
@@ -44,7 +44,7 @@ const DonorStatsArea = ({
   return (
     <StatAreaDisplay.Container className={className}>
       <StatAreaDisplay.Section>
-        {programDonorSummaryStats.registeredDonorsCount} donors
+        {programDonorSummaryStats.registeredDonorsCount.toLocaleString()} donors
       </StatAreaDisplay.Section>
       <StatAreaDisplay.Section>
         <Icon name="chevron_right" fill="grey_1" width="8px" />
@@ -54,7 +54,7 @@ const DonorStatsArea = ({
           <StatAreaDisplay.StarIcon
             fill={RELEASED_STATE_FILL_COLOURS[DonorDataReleaseState.FULLY]}
           />
-          {programDonorSummaryStats.fullyReleasedDonorsCount} with fully released files
+          {programDonorSummaryStats.fullyReleasedDonorsCount.toLocaleString()} with fully released files
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
       <StatAreaDisplay.Section>
@@ -62,7 +62,7 @@ const DonorStatsArea = ({
           <StatAreaDisplay.StarIcon
             fill={RELEASED_STATE_FILL_COLOURS[DonorDataReleaseState.PARTIALLY]}
           />
-          {programDonorSummaryStats.partiallyReleasedDonorsCount} with partially released files
+          {programDonorSummaryStats.partiallyReleasedDonorsCount.toLocaleString()} with partially released files
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
       <StatAreaDisplay.Section>
@@ -71,7 +71,7 @@ const DonorStatsArea = ({
             fill={RELEASED_STATE_FILL_COLOURS[DonorDataReleaseState.NO]}
             outline={RELEASED_STATE_STROKE_COLOURS[DonorDataReleaseState.NO]}
           />
-          {programDonorSummaryStats.noReleaseDonorsCount} with no released files
+          {programDonorSummaryStats.noReleaseDonorsCount.toLocaleString()} with no released files
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
       {programDonorSummaryStats.donorsInvalidWithCurrentDictionaryCount > 0 && (
@@ -91,7 +91,7 @@ const DonorStatsArea = ({
                 color: ${theme.colors.error_dark};
               `}
             >
-              {programDonorSummaryStats.donorsInvalidWithCurrentDictionaryCount} Invalid donors
+              {programDonorSummaryStats.donorsInvalidWithCurrentDictionaryCount.toLocaleString()} Invalid donors
             </span>
           </StatAreaDisplay.StatEntryContainer>
         </StatAreaDisplay.Section>

--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/InvalidDonorsNotification.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/InvalidDonorsNotification.tsx
@@ -46,10 +46,11 @@ export const InvalidDonorsNotification = ({ numInvalidDonors }: { numInvalidDono
     </div>
   );
 
-  const errorTitle = `${pluralize('donor', numInvalidDonors, true)} ${pluralize(
-    'is',
-    numInvalidDonors,
-  )} invalid and will be revoked if not corrected.`;
+  const errorTitle = `${numInvalidDonors.toLocaleString()} ${
+    pluralize('donor', numInvalidDonors)
+  } ${
+    pluralize('is', numInvalidDonors)
+  } invalid and will be revoked if not corrected.`;
 
   return numInvalidDonors > 0 ? (
     <Notification

--- a/components/pages/submission-system/program-dashboard/DonorReleaseSummary/index.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorReleaseSummary/index.tsx
@@ -71,7 +71,7 @@ export default () => {
               margin-right: 5px;
             `}
           >
-            {loading ? '...' : data.program.commitmentDonors}
+            {loading ? '...' : data.program.commitmentDonors.toLocaleString()}
           </Typography>
           <Typography variant="caption" color="grey">
             Committed

--- a/components/pages/submission-system/program-dashboard/StatsBar/index.tsx
+++ b/components/pages/submission-system/program-dashboard/StatsBar/index.tsx
@@ -105,7 +105,7 @@ export default () => {
           <Col>
             {!loading ? (
               <Statistic
-                quantity={`${data.programDonorSummaryStats.registeredDonorsCount}`}
+                quantity={data.programDonorSummaryStats.registeredDonorsCount.toLocaleString()}
                 description="Registered Donors"
               >
                 <PercentBar

--- a/components/pages/submission-system/program-management/ManageProgramTabs.tsx
+++ b/components/pages/submission-system/program-management/ManageProgramTabs.tsx
@@ -169,8 +169,11 @@ export default () => {
         title: '',
         content: (
           <span>
-            {successNames.length.toLocaleString()} {pluralize('user', successNames.length)} {successNames.length === 1 ? ' was' : 'were'} added to the
-            program: <br />
+            {`${successNames.length.toLocaleString()} ${
+            pluralize('user', successNames.length)
+            } ${
+              successNames.length === 1 ? ' was' : 'were'
+            } added to the program: `} <br />
             <strong>{successNames.join(', ')}</strong>
           </span>
         ),
@@ -182,7 +185,9 @@ export default () => {
         title: '',
         content: (
           <span>
-            {failNames.length.toLocaleString()} {pluralize('user', failNames.length)} could not be added to the program:{' '}
+            {`${failNames.length.toLocaleString()} ${
+              pluralize('user', failNames.length)
+            } could not be added to the program: `}
             <br />
             <strong>{failNames.join(', ')}</strong>
           </span>

--- a/components/pages/submission-system/program-management/ManageProgramTabs.tsx
+++ b/components/pages/submission-system/program-management/ManageProgramTabs.tsx
@@ -20,6 +20,7 @@
 import React from 'react';
 import useAuthContext from 'global/hooks/useAuthContext';
 import isEmpty from 'lodash/isEmpty';
+import pluralize from 'pluralize';
 import { useRouter } from 'next/router';
 import { useQuery, useMutation } from '@apollo/react-hooks';
 import { css } from 'uikit';
@@ -168,7 +169,7 @@ export default () => {
         title: '',
         content: (
           <span>
-            {successNames.length} user{successNames.length === 1 ? ' was' : 's were'} added to the
+            {successNames.length.toLocaleString()} {pluralize('user', successNames.length)} {successNames.length === 1 ? ' was' : 'were'} added to the
             program: <br />
             <strong>{successNames.join(', ')}</strong>
           </span>
@@ -181,7 +182,7 @@ export default () => {
         title: '',
         content: (
           <span>
-            {failNames.length} user{failNames.length > 1 && 's'} could not be added to the program:{' '}
+            {failNames.length.toLocaleString()} {pluralize('user', failNames.length)} could not be added to the program:{' '}
             <br />
             <strong>{failNames.join(', ')}</strong>
           </span>

--- a/components/pages/submission-system/program-management/Users.tsx
+++ b/components/pages/submission-system/program-management/Users.tsx
@@ -69,7 +69,7 @@ const Users = ({
 
   return (
     <div>
-      <TableActionBar>{users.length} results</TableActionBar>
+      <TableActionBar>{users.length.toLocaleString()} results</TableActionBar>
       <UsersTable
         loading={loading}
         users={users}

--- a/components/pages/submission-system/program-sample-registration/FileTable/index.tsx
+++ b/components/pages/submission-system/program-sample-registration/FileTable/index.tsx
@@ -61,7 +61,7 @@ const StatsArea = (props: { stats?: FileStats }) => {
   return (
     <StatAreaDisplay.Container>
       <StatAreaDisplay.Section>
-        {stats ? stats.existingCount + stats.newCount : 0} Total
+        {stats ? (stats.existingCount + stats.newCount).toLocaleString() : 0} Total
       </StatAreaDisplay.Section>
       <StatAreaDisplay.Section>
         <Icon name="chevron_right" fill="grey_1" width="8px" />
@@ -69,13 +69,13 @@ const StatsArea = (props: { stats?: FileStats }) => {
       <StatAreaDisplay.Section>
         <StatAreaDisplay.StatEntryContainer>
           <StatAreaDisplay.StarIcon fill="accent2" />
-          {stats && stats.newCount} New
+          {stats && stats.newCount.toLocaleString()} New
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
       <StatAreaDisplay.Section>
         <StatAreaDisplay.StatEntryContainer>
           <StatAreaDisplay.StarIcon fill="grey_1" />
-          {stats && stats.existingCount} Already Registered
+          {stats && stats.existingCount.toLocaleString()} Already Registered
         </StatAreaDisplay.StatEntryContainer>
       </StatAreaDisplay.Section>
     </StatAreaDisplay.Container>

--- a/components/pages/submission-system/program-sample-registration/Instructions/RegisterSamplesModal.tsx
+++ b/components/pages/submission-system/program-sample-registration/Instructions/RegisterSamplesModal.tsx
@@ -84,7 +84,7 @@ export default function RegisterSamplesModal({
 
         toaster.addToast({
           interactionType: 'CLOSE',
-          title: `${num} new registered ${pluralize('sample', num)}`,
+          title: `${num.toLocaleString()} new registered ${pluralize('sample', num)}`,
           variant: TOAST_VARIANTS.SUCCESS,
           content: (
             <Typography>

--- a/components/pages/submission-system/program-sample-registration/index.tsx
+++ b/components/pages/submission-system/program-sample-registration/index.tsx
@@ -278,7 +278,7 @@ export default function ProgramIDRegistration() {
           <ErrorNotification
             level={NOTIFICATION_VARIANTS.ERROR}
             onClearClick={handleClearClick}
-            title={`${schemaOrValidationErrors.length} error(s) found in uploaded file`}
+            title={`${schemaOrValidationErrors.length.toLocaleString()} error(s) found in uploaded file`}
             errors={schemaOrValidationErrors.map(toDisplayError)}
             subtitle={
               'Your file cannot be processed. Please correct the following errors and reupload your file.'

--- a/components/pages/submission-system/programs/index.tsx
+++ b/components/pages/submission-system/programs/index.tsx
@@ -131,7 +131,7 @@ export default function Programs({ authorizedPrograms = [] }: any) {
         loading={loading}
       >
         <TableActionBar>
-          {programs.length} results
+          {programs.length.toLocaleString()} results
           {/*   <TableFilterInput /> */}
         </TableActionBar>
         <ProgramsTable

--- a/uikit/OptionsList/index.tsx
+++ b/uikit/OptionsList/index.tsx
@@ -163,7 +163,7 @@ const OptionsList: React.ComponentType<{
             margin-left: 5px;
           `}
         >
-          {option.doc_count}
+          {option.doc_count.toLocaleString()}
         </Tag>
       </div>
     );

--- a/uikit/PercentageBar/index.tsx
+++ b/uikit/PercentageBar/index.tsx
@@ -66,7 +66,7 @@ const PercentageBar = ({
       `}
     >
       <VAlignedText>
-        {nom} <Icon name="slash" height="15px" fill="grey_2" /> {denom}
+        {nom.toLocaleString()} <Icon name="slash" height="15px" fill="grey_2" /> {denom.toLocaleString()}
       </VAlignedText>
       <VAlignedText
         css={css`


### PR DESCRIPTION
**Description of changes**

- add commas to large numbers in text with `toLocaleString`
- aside from the requested changes, I looked for other instances of "pluralize" "count" and ".length"
- added screenshots to the ticket with everything i changed

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories (no story updates needed)
  - [ ] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
