### PR TITLE
add tag colour for editable values

### DIFF
--- a/uikit/Tag/index.tsx
+++ b/uikit/Tag/index.tsx
@@ -22,8 +22,18 @@ import styled from '@emotion/styled';
 import css from '@emotion/css';
 import defaultTheme from 'uikit/theme/defaultTheme';
 
-type TagVariant = 'INFO' | 'WARNING' | 'ERROR' | 'SUCCESS' | 'UPDATE' | 'NEUTRAL' | 'HIGHLIGHT';
+type TagVariant =
+  | 'EDITABLE'
+  | 'ERROR'
+  | 'HIGHLIGHT'
+  | 'INFO'
+  | 'NEUTRAL'
+  | 'SUCCESS'
+  | 'UPDATE'
+  | 'WARNING';
+
 export const TAG_VARIANTS: { [k in TagVariant]: k } = {
+  EDITABLE: 'EDITABLE',
   INFO: 'INFO',
   WARNING: 'WARNING',
   ERROR: 'ERROR',
@@ -49,6 +59,7 @@ const Tag = styled<'div', { variant?: keyof typeof TAG_VARIANTS }>('div')`
   border-radius: 8px;
   background-color: ${({ theme, variant = 'INFO' }) =>
     ({
+      [TAG_VARIANTS.EDITABLE]: theme.colors.accent2,
       [TAG_VARIANTS.ERROR]: theme.colors.error,
       [TAG_VARIANTS.WARNING]: theme.colors.warning,
       [TAG_VARIANTS.INFO]: theme.colors.secondary,


### PR DESCRIPTION
**Description of changes**

Adds a new purple background colour option to the Tag, as the component is being used for the new DACO app.
![image](https://user-images.githubusercontent.com/2107110/118528824-cd7fda00-b710-11eb-9272-b342773dd1dc.png)


**Type of Change**

- [ ] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [x] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
