### PR TITLE
add disabled functionality for vertical tabs

### DIFF
--- a/components/pages/submission-system/donor/ClinicalTimeline/Timeline.tsx
+++ b/components/pages/submission-system/donor/ClinicalTimeline/Timeline.tsx
@@ -86,28 +86,13 @@ const TimelineItem = ({ item, active, onClick, disabled }: TimeLineItemProps) =>
       `}
     >
       <VerticalTabs.Item
+        disabled
         tabStyle={{ border: borderColor, background: backgroundColor }}
         css={css`
           height: 100%;
           width: 100%;
           border: 0;
           color: black;
-
-          &:focus {
-            ${disabled
-              ? css`
-                  box-shadow: none;
-                `
-              : null};
-          }
-          &:hover {
-            ${disabled
-              ? css`
-                  background: white;
-                  cursor: default;
-                `
-              : null}
-          }
         `}
         active={active}
       >

--- a/uikit/Tag/index.tsx
+++ b/uikit/Tag/index.tsx
@@ -23,6 +23,7 @@ import css from '@emotion/css';
 import defaultTheme from 'uikit/theme/defaultTheme';
 
 type TagVariant =
+  | 'DISABLED'
   | 'EDITABLE'
   | 'ERROR'
   | 'HIGHLIGHT'
@@ -33,6 +34,7 @@ type TagVariant =
   | 'WARNING';
 
 export const TAG_VARIANTS: { [k in TagVariant]: k } = {
+  DISABLED: 'DISABLED',
   EDITABLE: 'EDITABLE',
   INFO: 'INFO',
   WARNING: 'WARNING',
@@ -59,13 +61,14 @@ const Tag = styled<'div', { variant?: keyof typeof TAG_VARIANTS }>('div')`
   border-radius: 8px;
   background-color: ${({ theme, variant = 'INFO' }) =>
     ({
+      [TAG_VARIANTS.DISABLED]: theme.colors.grey_2,
       [TAG_VARIANTS.EDITABLE]: theme.colors.accent2,
       [TAG_VARIANTS.ERROR]: theme.colors.error,
       [TAG_VARIANTS.WARNING]: theme.colors.warning,
       [TAG_VARIANTS.INFO]: theme.colors.secondary,
       [TAG_VARIANTS.SUCCESS]: theme.colors.accent1_dimmed,
       [TAG_VARIANTS.UPDATE]: theme.colors.accent3_dark,
-      [TAG_VARIANTS.NEUTRAL]: theme.colors.grey_2,
+      [TAG_VARIANTS.NEUTRAL]: theme.colors.primary_2,
       [TAG_VARIANTS.HIGHLIGHT]: theme.colors.secondary_2,
     }[variant])};
   color: ${({ variant = 'INFO' }) =>

--- a/uikit/VerticalTabs/index.tsx
+++ b/uikit/VerticalTabs/index.tsx
@@ -17,13 +17,18 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { HtmlHTMLAttributes, HTMLAttributes } from 'react';
+import React, { HtmlHTMLAttributes, HTMLAttributes, MouseEventHandler } from 'react';
 import { useTheme } from '../ThemeProvider';
 import { css, styled } from '..';
 import Typography from 'uikit/Typography';
 import Tag from 'uikit/Tag';
 import FocusWrapper from 'uikit/FocusWrapper';
 import useElementDimension from 'uikit/utils/Hook/useElementDimension';
+
+type TabStyleType = {
+  background: string;
+  border: string;
+};
 
 const Triangle = styled('div')<{ tabStyle: TabStyleType; contHeight: number }>`
   transition: all 0.25s;
@@ -56,7 +61,7 @@ const Triangle = styled('div')<{ tabStyle: TabStyleType; contHeight: number }>`
   }
 `;
 
-const BaseItemContainer = styled(FocusWrapper)<{ tabStyle: TabStyleType }>`
+const BaseItemContainer = styled(FocusWrapper)<{ tabStyle: TabStyleType; disabled?: boolean }>`
   width: 100%;
   position: relative;
   transition: all 0.25s;
@@ -69,10 +74,23 @@ const BaseItemContainer = styled(FocusWrapper)<{ tabStyle: TabStyleType }>`
   border-left: solid 3px;
   border-right: none;
   border-color: rgba(0, 0, 0, 0);
-  cursor: pointer;
-  &:hover {
-    background: ${({ theme }) => theme.colors.grey_3};
-  }
+  ${({ disabled, theme }) =>
+    disabled
+      ? `
+          &:focus {
+            box-shadow: none;
+          }
+
+          &:hover {
+            cursor: default;
+          }
+        `
+      : `
+          &:hover {
+            cursor: pointer;
+            background: ${theme.colors.grey_3};
+          }
+        `}
 `;
 const ActiveItemContainer = styled(BaseItemContainer)<{ tabStyle: TabStyleType }>`
   border-color: ${({ theme }) => theme.colors.secondary};
@@ -92,18 +110,29 @@ const ActiveItemContainer = styled(BaseItemContainer)<{ tabStyle: TabStyleType }
   }
 `;
 
-type TabStyleType = { border: string; background: string };
-
 const VerticalTabsItem: React.ComponentType<
-  { active?: boolean; tabStyle?: TabStyleType } & HTMLAttributes<HTMLButtonElement>
-> = ({ active = false, children, tabStyle, ...rest }) => {
+  {
+    active?: boolean;
+    disabled?: boolean;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    tabStyle?: TabStyleType;
+  } & HTMLAttributes<HTMLButtonElement>
+> = ({ active = false, children, disabled = false, onClick = () => {}, tabStyle, ...rest }) => {
   const ContainerComponent = active ? ActiveItemContainer : BaseItemContainer;
   const containerRef = React.useRef(null);
 
   const { height: contHeight } = useElementDimension(containerRef);
 
+  const clickHandler = (event) => disabled || onClick(event);
+
   return (
-    <ContainerComponent tabStyle={tabStyle} {...rest} ref={containerRef}>
+    <ContainerComponent
+      tabStyle={tabStyle}
+      disabled={disabled}
+      onClick={clickHandler}
+      {...rest}
+      ref={containerRef}
+    >
       <Typography
         variant="data"
         as="div"

--- a/uikit/VerticalTabs/stories.tsx
+++ b/uikit/VerticalTabs/stories.tsx
@@ -24,7 +24,7 @@ import { action } from '@storybook/addon-actions';
 
 const VerticalTabsStories = storiesOf(`${__dirname}`, module).add('Basic', () => {
   const [activeItem, setActiveItem] = React.useState(0);
-  const onClick = (num: number) => e => {
+  const onClick = (num: number) => (e) => {
     setActiveItem(num);
     action('VerticalTabs.Item onClick')(e);
   };
@@ -47,7 +47,7 @@ const VerticalTabsStories = storiesOf(`${__dirname}`, module).add('Basic', () =>
           Donor
           <VerticalTabs.Tag variant="ERROR">!</VerticalTabs.Tag>
         </VerticalTabs.Item>
-        <VerticalTabs.Item onClick={onClick(3)} active={activeItem === 3}>
+        <VerticalTabs.Item disabled onClick={onClick(3)} active={activeItem === 3}>
           Donor
           <VerticalTabs.Tag variant="SUCCESS">45</VerticalTabs.Tag>
         </VerticalTabs.Item>


### PR DESCRIPTION
**Description of changes**

allows passing a new `disabled` props to the <VerticalTabs.item /> to disallow clicking on the tabs, and so people don't have to implement css customisation to reach the desired effect.

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
