### PR TITLE
HOTFIX - Remove release_stage from facet query

### DIFF
--- a/components/pages/file-repository/FacetPanel/FILE_REPOSITORY_FACETS_QUERY.gql
+++ b/components/pages/file-repository/FacetPanel/FILE_REPOSITORY_FACETS_QUERY.gql
@@ -7,12 +7,6 @@ query FILE_REPOSITORY_FACETS_QUERY($filters: JSON) {
           doc_count
         }
       }
-      release_stage {
-        buckets {
-          doc_count
-          key
-        }
-      }
       analysis__experiment__experimental_strategy {
         buckets {
           key

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argo-platform-ui",
-  "version": "1.93.3",
+  "version": "1.93.2",
   "scripts": {
     "dev": "next -p 8080",
     "build": "rm -rf .next && next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argo-platform-ui",
-  "version": "1.93.2",
+  "version": "1.93.3",
   "scripts": {
     "dev": "next -p 8080",
     "build": "rm -rf .next && next build",


### PR DESCRIPTION
**Description of changes**
Release state is no longer available in the file-centric index mapping, meaning an error is thrown by arranger when this is requested by the UI. Since we are not using this piece of data, we should remove it from the api request. Hotfix to get these changes into staging and prod where we are observing this behaviour.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
