### PR TITLE
add optional tooltips to vertical tabs

### DIFF
--- a/uikit/Tooltip/index.tsx
+++ b/uikit/Tooltip/index.tsx
@@ -64,7 +64,12 @@ export type TooltipProps = {
   style?: {};
 };
 
-const Tooltip: React.ComponentType<TooltipProps> = ({ html, position = 'top', ...rest }) => {
+const Tooltip: React.ComponentType<TooltipProps> = ({
+  className,
+  html,
+  position = 'top',
+  ...rest
+}) => {
   const theme = useTheme();
   const arrowStyles = {
     top: `
@@ -146,7 +151,11 @@ const Tooltip: React.ComponentType<TooltipProps> = ({ html, position = 'top', ..
             rest.popperOptions,
           ),
         }}
-        html={<TooltipContainer id="tooltip">{html}</TooltipContainer>}
+        html={
+          <TooltipContainer className={className} id="tooltip">
+            {html}
+          </TooltipContainer>
+        }
         position={position}
         {...rest}
       />

--- a/uikit/VerticalTabs/index.tsx
+++ b/uikit/VerticalTabs/index.tsx
@@ -17,13 +17,20 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { HtmlHTMLAttributes, HTMLAttributes, MouseEventHandler } from 'react';
+import React, {
+  HtmlHTMLAttributes,
+  HTMLAttributes,
+  ReactNode,
+  ReactElement,
+  MouseEventHandler,
+} from 'react';
 import { useTheme } from '../ThemeProvider';
 import { css, styled } from '..';
 import Typography from 'uikit/Typography';
 import Tag from 'uikit/Tag';
 import FocusWrapper from 'uikit/FocusWrapper';
 import useElementDimension from 'uikit/utils/Hook/useElementDimension';
+import Tooltip from 'uikit/Tooltip';
 
 type TabStyleType = {
   background: string;
@@ -116,8 +123,17 @@ const VerticalTabsItem: React.ComponentType<
     disabled?: boolean;
     onClick?: MouseEventHandler<HTMLButtonElement>;
     tabStyle?: TabStyleType;
+    tooltip?: ReactNode;
   } & HTMLAttributes<HTMLButtonElement>
-> = ({ active = false, children, disabled = false, onClick = () => {}, tabStyle, ...rest }) => {
+> = ({
+  active = false,
+  children,
+  disabled = false,
+  onClick = () => {},
+  tabStyle,
+  tooltip,
+  ...rest
+}) => {
   const ContainerComponent = active ? ActiveItemContainer : BaseItemContainer;
   const containerRef = React.useRef(null);
 
@@ -126,35 +142,45 @@ const VerticalTabsItem: React.ComponentType<
   const clickHandler = (event) => disabled || onClick(event);
 
   return (
-    <ContainerComponent
-      tabStyle={tabStyle}
-      disabled={disabled}
-      onClick={clickHandler}
-      {...rest}
-      ref={containerRef}
+    <Tooltip
+      css={css`
+        // these are applied to the internal container of the tooltip
+        max-width: 200px;
+      `}
+      disabled={!tooltip}
+      html={tooltip}
+      position="right"
     >
-      <Typography
-        variant="data"
-        as="div"
-        css={css`
-          width: 100%;
-        `}
+      <ContainerComponent
+        tabStyle={tabStyle}
+        disabled={disabled}
+        onClick={clickHandler}
+        {...rest}
+        ref={containerRef}
       >
-        <div
+        <Typography
+          variant="data"
+          as="div"
           css={css`
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            text-align: left;
+            width: 100%;
           `}
         >
-          {children}
-        </div>
-      </Typography>
-      {active && (
-        <Triangle tabStyle={tabStyle} contHeight={contHeight} className="activeTriangle" />
-      )}
-    </ContainerComponent>
+          <div
+            css={css`
+              display: flex;
+              justify-content: space-between;
+              align-items: center;
+              text-align: left;
+            `}
+          >
+            {children}
+          </div>
+        </Typography>
+        {active && (
+          <Triangle tabStyle={tabStyle} contHeight={contHeight} className="activeTriangle" />
+        )}
+      </ContainerComponent>
+    </Tooltip>
   );
 };
 VerticalTabsItem.displayName = 'VerticalTabs.Item';

--- a/uikit/VerticalTabs/stories.tsx
+++ b/uikit/VerticalTabs/stories.tsx
@@ -17,10 +17,26 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { storiesOf } from '@storybook/react';
 import React from 'react';
-import VerticalTabs from '.';
+import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+
+import { css } from '..';
+import VerticalTabs from '.';
+
+const LoremTooltip = (
+  <>
+    <p>Lorem Ipsum dolor:</p>
+    <ul
+      css={css`
+        padding-left: 15px;
+      `}
+    >
+      <li>palo santo</li>
+      <li>kombucha</li>
+    </ul>
+  </>
+);
 
 const VerticalTabsStories = storiesOf(`${__dirname}`, module).add('Basic', () => {
   const [activeItem, setActiveItem] = React.useState(0);
@@ -31,11 +47,11 @@ const VerticalTabsStories = storiesOf(`${__dirname}`, module).add('Basic', () =>
   return (
     <div style={{ width: '50%' }}>
       <VerticalTabs>
-        <VerticalTabs.Item onClick={onClick(0)} active={activeItem === 0}>
+        <VerticalTabs.Item tooltip="Donor" onClick={onClick(0)} active={activeItem === 0}>
           Donor
           <VerticalTabs.Tag variant="UPDATE">12</VerticalTabs.Tag>
         </VerticalTabs.Item>
-        <VerticalTabs.Item onClick={onClick(1)} active={activeItem === 1}>
+        <VerticalTabs.Item tooltip="Specimen" onClick={onClick(1)} active={activeItem === 1}>
           Specimen
           <br />
           larger tab
@@ -51,7 +67,7 @@ const VerticalTabsStories = storiesOf(`${__dirname}`, module).add('Basic', () =>
           Donor
           <VerticalTabs.Tag variant="SUCCESS">45</VerticalTabs.Tag>
         </VerticalTabs.Item>
-        <VerticalTabs.Item onClick={onClick(4)} active={activeItem === 4}>
+        <VerticalTabs.Item tooltip={LoremTooltip} onClick={onClick(4)} active={activeItem === 4}>
           Lorem ipsum dolor amet palo santo kombucha
           <VerticalTabs.Tag variant="SUCCESS">45</VerticalTabs.Tag>
         </VerticalTabs.Item>


### PR DESCRIPTION
**Description of changes**

allows displaying a tooltip (optional) whenever you hover over a tab item, like so:
![image](https://user-images.githubusercontent.com/2107110/119064259-f1f5e380-b9a8-11eb-9175-da2e88711194.png)

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [x] Connected ticket to PR
