### PR TITLE
fix FormCheckbox not getting onChange without RadioGroup

### DIFF
--- a/uikit/form/FormCheckbox/index.tsx
+++ b/uikit/form/FormCheckbox/index.tsx
@@ -17,23 +17,29 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useContext } from 'react';
-import PropTypes from 'prop-types';
-import { RadioCheckboxWrapper, StyledGroup } from '../common';
+import React, { ReactNode, useContext } from 'react';
+import { RadioCheckboxWrapper } from '../common';
 import Checkbox from '../Checkbox';
 import css from '@emotion/css';
 import RadioCheckContext from '../RadioCheckboxGroup/RadioCheckContext';
 
-/**
- * Checkbox for Form
- * To be used with RadioCheckboxGroup
- */
-const FormCheckbox = props => {
-  const { id, name, value, label, children, disabled, type, checked } = props;
+const FormCheckbox = ({
+  checked,
+  children,
+  disabled,
+  value,
+  ...props
+}: {
+  checked?: boolean;
+  children: ReactNode;
+  disabled?: boolean;
+  onChange?: (any) => any;
+  value?: string;
+}) => {
+  const { onChange = props.onChange, isChecked } = useContext(RadioCheckContext);
 
-  const { onChange, isChecked = props.isChecked } = useContext(RadioCheckContext) || props;
   const onClick = () => onChange(value);
-  const calcChecked = isChecked ? isChecked(value) : checked;
+  const calcChecked = typeof isChecked === 'function' ? isChecked(value) : isChecked || checked;
 
   return (
     <RadioCheckboxWrapper disabled={disabled} checked={calcChecked} onClick={onClick}>
@@ -53,16 +59,6 @@ const FormCheckbox = props => {
       </label>
     </RadioCheckboxWrapper>
   );
-};
-
-FormCheckbox.propTypes = {
-  id: PropTypes.string,
-  name: PropTypes.string,
-  value: PropTypes.any,
-  label: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  checked: PropTypes.bool,
-  onChange: PropTypes.func,
 };
 
 export default FormCheckbox;

--- a/uikit/form/FormCheckbox/stories.tsx
+++ b/uikit/form/FormCheckbox/stories.tsx
@@ -20,17 +20,27 @@
 import { storiesOf } from '@storybook/react';
 import React, { useState } from 'react';
 import FormCheckbox from '.';
-import { boolean, button } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import RadioCheckboxGroup from '../RadioCheckboxGroup';
 
 const createKnobs = () => {
-  const checked = boolean('checked', false);
+  const [checked, setChecked] = useState(false);
   const disabled = boolean('disabled', false);
+  const value = 'myCheckbox';
 
   return {
     checked,
     disabled,
+    onChange: () => {
+      if (disabled) {
+        action('checkbox clicked while disabled')(value, checked);
+      } else {
+        action('checkbox clicked')(value, !checked);
+        setChecked(!checked);
+      }
+    },
+    value,
   };
 };
 
@@ -46,9 +56,9 @@ const CheckboxStories = storiesOf(`${__dirname}`, module)
     </FormCheckbox>
   ))
   .add('Checkbox Group', () => {
-    const [selectedItems, setSelected] = React.useState(new Set([]));
-    const isChecked = item => selectedItems.has(item);
-    const onChange = value => {
+    const [selectedItems, setSelected] = useState(new Set([]));
+    const isChecked = (item) => selectedItems.has(item);
+    const onChange = (value) => {
       selectedItems.has(value) ? selectedItems.delete(value) : selectedItems.add(value);
       const newSelectedItems = new Set(selectedItems);
       action('checkbox clicked')(value, Array.from(newSelectedItems));


### PR DESCRIPTION
**Description of changes**

Restores functionality for individual `FormCheckbox`s (i.e. without needing a `RadioCheckboxGroup` context).
Bonus: migrates the component to TS, and adds Storybook actions.

Testable at https://fix-single-formcheckbox--argo-ui-storybook.netlify.app/?path=/story/uikit-form-formcheckbox--default

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [x] Connected ticket to PR
