### PR TITLE
allow FormHelperText to behave as error message

### DIFF
--- a/uikit/form/FormControl/stories.tsx
+++ b/uikit/form/FormControl/stories.tsx
@@ -42,7 +42,7 @@ const FormControlStories = storiesOf(`${__dirname}`, module)
             aria-label="multi-select"
             inputProps={{ id: 'country' }}
             value={value}
-            onChange={event => setValue(event.target.value)}
+            onChange={(event) => setValue(event.target.value)}
             placeholder="Add one or more..."
           >
             <Option value="Australia">Australia</Option>
@@ -72,6 +72,7 @@ const FormControlStories = storiesOf(`${__dirname}`, module)
         <InputLabel htmlFor="text-input">text input</InputLabel>
         <Input aria-label="text input" id="text-input" placeholder="put some text" />
         <FormHelperText>Some helper text</FormHelperText>
+        <FormHelperText onErrorOnly>This field has an error!</FormHelperText>
       </FormControl>
     ),
     {

--- a/uikit/form/FormHelperText/index.tsx
+++ b/uikit/form/FormHelperText/index.tsx
@@ -18,7 +18,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import FormControlContext from '../FormControl/FormControlContext';
 import styled from '@emotion/styled';
 import clsx from 'clsx';
@@ -38,9 +37,19 @@ const FormHelperText = React.forwardRef<
      */
     className?: string;
     children?: React.ReactNode | React.ReactNodeArray;
+    /**
+     * Allows turning this component into an error-dependent message.
+     * Hides it when no errors are present. Else,
+     */
+    onErrorOnly?: boolean;
   }
 >(function FormHelperText(props, ref) {
-  const { component: Component = 'p', className: classNameProp, children } = props;
+  const {
+    component: Component = 'p',
+    className: classNameProp,
+    children,
+    onErrorOnly = false,
+  } = props;
 
   const StyledComponent = styled<any, any>(Component)`
     ${({ theme }) => css(theme.typography.caption)};
@@ -58,13 +67,15 @@ const FormHelperText = React.forwardRef<
 
   const contextValue = React.useContext(FormControlContext);
 
-  return (
+  return !onErrorOnly || contextValue.error ? (
     <StyledComponent
       ref={ref}
       className={clsx(pick(contextValue, ['error', 'disabled']), classNameProp)}
     >
       {children}
     </StyledComponent>
+  ) : (
+    <></>
   );
 });
 

--- a/uikit/form/FormHelperText/index.tsx
+++ b/uikit/form/FormHelperText/index.tsx
@@ -61,7 +61,7 @@ const FormHelperText = React.forwardRef<
     }
 
     &.disabled {
-      display: none;
+      ${!onErrorOnly && `display: none;`}
     }
   `;
 


### PR DESCRIPTION
**Description of changes**

Allows making `FormHelperText` behave like an error message, hiding it when there's no errors to show.
Added it to `FormControl`'s story, to document visually the functionality: https://feature-formhelpertext-onerroronly--argo-ui-storybook.netlify.app/?path=/story/uikit-form-formcontrol--input

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [x] Connected ticket to PR
