### PR TITLE
integrate FormCheckbox into FormControl

### DIFF
--- a/uikit/form/FormCheckbox/index.tsx
+++ b/uikit/form/FormCheckbox/index.tsx
@@ -18,15 +18,18 @@
  */
 
 import React, { ReactNode, useContext } from 'react';
-import { RadioCheckboxWrapper } from '../common';
+
+import { css, UikitTheme } from '../../';
+import Icon from '../../Icon';
+import { useTheme } from '../../ThemeProvider';
 import Checkbox from '../Checkbox';
-import css from '@emotion/css';
+import { RadioCheckboxWrapper } from '../common';
+import FormControlContext from '../FormControl/FormControlContext';
 import RadioCheckContext from '../RadioCheckboxGroup/RadioCheckContext';
 
 const FormCheckbox = ({
   checked,
   children,
-  disabled,
   value,
   ...props
 }: {
@@ -34,15 +37,23 @@ const FormCheckbox = ({
   children: ReactNode;
   disabled?: boolean;
   onChange?: (any) => any;
+  error?: boolean;
+  required?: boolean;
   value?: string;
 }) => {
+  const theme: UikitTheme = useTheme();
   const { onChange = props.onChange, isChecked } = useContext(RadioCheckContext);
+  const {
+    disabled = props.disabled,
+    error = props.error,
+    required = props.required,
+  } = React.useContext(FormControlContext);
 
   const onClick = () => onChange(value);
   const calcChecked = typeof isChecked === 'function' ? isChecked(value) : isChecked || checked;
 
   return (
-    <RadioCheckboxWrapper disabled={disabled} checked={calcChecked} onClick={onClick}>
+    <RadioCheckboxWrapper checked={calcChecked} disabled={disabled} error={error} onClick={onClick}>
       <Checkbox
         value={value}
         checked={calcChecked}
@@ -50,12 +61,28 @@ const FormCheckbox = ({
         onChange={onChange}
         aria-label={props['aria-label']}
       />
+
       <label
         css={css`
           margin-left: 8px;
         `}
       >
         {children}
+
+        {required && (
+          <span>
+            <Icon
+              css={css`
+                margin-bottom: 5px;
+                margin-left: 5px;
+              `}
+              width="6px"
+              height="6px"
+              name="asterisk"
+              fill={theme.colors.error}
+            />
+          </span>
+        )}
       </label>
     </RadioCheckboxWrapper>
   );

--- a/uikit/form/FormCheckbox/stories.tsx
+++ b/uikit/form/FormCheckbox/stories.tsx
@@ -27,11 +27,14 @@ import RadioCheckboxGroup from '../RadioCheckboxGroup';
 const createKnobs = () => {
   const [checked, setChecked] = useState(false);
   const disabled = boolean('disabled', false);
+  const error = boolean('error', false);
+  const required = boolean('required', false);
   const value = 'myCheckbox';
 
   return {
     checked,
     disabled,
+    error,
     onChange: () => {
       if (disabled) {
         action('checkbox clicked while disabled')(value, checked);
@@ -40,6 +43,7 @@ const createKnobs = () => {
         setChecked(!checked);
       }
     },
+    required,
     value,
   };
 };

--- a/uikit/form/FormControl/FormControlContext.tsx
+++ b/uikit/form/FormControl/FormControlContext.tsx
@@ -22,11 +22,10 @@ import React from 'react';
 const FormControlContext = React.createContext<{
   disabled?: boolean;
   error?: string | boolean;
-
-  required?: boolean;
   focused?: boolean;
   handleFocus?: () => void;
   handleBlur?: () => any;
+  required?: boolean;
 }>({});
 
 export default FormControlContext;

--- a/uikit/form/FormControl/index.tsx
+++ b/uikit/form/FormControl/index.tsx
@@ -49,8 +49,8 @@ const FormControl = React.forwardRef<
 >(function FormControl(
   {
     component: Component = 'div' as any,
-    error = false,
     disabled = false,
+    error = false,
     required = false,
     ...other
   },

--- a/uikit/form/FormControl/stories.tsx
+++ b/uikit/form/FormControl/stories.tsx
@@ -17,16 +17,60 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+
 import FormControl from '.';
 import FormHelperText from '../FormHelperText';
 import InputLabel from '../InputLabel';
 import MultiSelect, { Option } from '../../form/MultiSelect';
-import { boolean } from '@storybook/addon-knobs';
 import Input from '../../form/Input';
+import FormCheckbox from '../FormCheckbox';
+import Typography from '../../Typography';
 
 const FormControlStories = storiesOf(`${__dirname}`, module)
+  .add(
+    'FormCheckbox',
+    () => {
+      const [checked, setChecked] = useState(false);
+      const disabled = boolean('disabled', false);
+      const error = boolean('error', false);
+      const required = boolean('required', true);
+      const value = 'myCheckbox';
+
+      return (
+        <FormControl disabled={disabled} error={error} required={required}>
+          <FormCheckbox
+            aria-label="I agree with the terms and conditions"
+            checked={checked}
+            onChange={() => {
+              if (disabled) {
+                action('checkbox clicked while disabled')(value, checked);
+              } else {
+                action('checkbox clicked')(value, !checked);
+                setChecked(!checked);
+              }
+            }}
+            value={value}
+          >
+            <Typography bold component="span">
+              I agree
+            </Typography>{' '}
+            with the terms and conditions.
+          </FormCheckbox>
+
+          <FormHelperText onErrorOnly>This field is required!</FormHelperText>
+        </FormControl>
+      );
+    },
+    {
+      info: {
+        propTablesExclude: [FormCheckbox, Typography],
+      },
+    },
+  )
   .add(
     'MultiSelect',
     () => {

--- a/uikit/form/common.tsx
+++ b/uikit/form/common.tsx
@@ -84,6 +84,7 @@ export const StyledInputWrapper = styled<'div', StyledInputWrapperProps>('div')`
 `;
 
 type RadioCheckboxWrapperProps = {
+  error?: boolean | string;
   disabled?: boolean;
   checked?: boolean;
 };
@@ -94,7 +95,8 @@ export const RadioCheckboxWrapper = styled<'div', RadioCheckboxWrapperProps>('di
   margin-bottom: 2px;
   border-width: 1px;
   border-style: solid;
-  border-color: ${({ theme }) => theme.radiocheckbox.borderColors.default};
+  border-color: ${({ error, theme }) =>
+    error ? theme.radiocheckbox.borderColors.error : theme.radiocheckbox.borderColors.default};
 
   background-color: ${({ theme, disabled, checked }) =>
     theme.radiocheckbox.backgroundColors[disabled ? 'disabled' : checked ? 'checked' : 'default']};

--- a/uikit/theme/defaultTheme/radiocheckbox.tsx
+++ b/uikit/theme/defaultTheme/radiocheckbox.tsx
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
  *
@@ -36,6 +35,7 @@ export default {
   borderColors: {
     default: colors.grey_2,
     disabled: '#d0d1d8',
+    error: colors.error,
   },
   radio: {
     default: colors.grey_1,


### PR DESCRIPTION
**Description of changes**

Enables `FormControls` context and functionalities to be used in `FormCheckbox` components, including displaying the `required`  star and `error` statuses. 

Feature fully testable in this new `FormControl` story: https://feature-integrate-formcontrol-formcheckbox--argo-ui-storybook.netlify.app/?path=/story/uikit-form-formcontrol--formcheckbox

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [x] Connected ticket to PR
