### PR TITLE
add checkbox focus and blur functionalities

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -1,4 +1,4 @@
-NODE_PATH=./
+NODE_PATH=/
 NODE_ENV=development | production
 AUTH_DISABLED=false
 

--- a/components/pages/submission-system/program-form/ProgramForm.tsx
+++ b/components/pages/submission-system/program-form/ProgramForm.tsx
@@ -168,7 +168,9 @@ export default function CreateProgramForm({
   const handleCheckboxGroupChange = (
     selectedItems: any[],
     fieldName: keyof typeof seedFormData,
-  ) => (value) => {
+  ) => (event) => {
+    const value = event.target?.defaultValue;
+
     if (selectedItems.includes(value)) {
       setData({ key: fieldName, val: filter(selectedItems, (item) => item !== value) });
     } else {

--- a/uikit/form/Checkbox/index.tsx
+++ b/uikit/form/Checkbox/index.tsx
@@ -17,8 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { RefObject } from 'react';
 import styled from '@emotion/styled';
 
 /**
@@ -42,6 +41,7 @@ export const StyledCheckbox = styled<
 >('div')`
   position: relative;
   cursor: pointer;
+  width: min-content;
 
   input {
     margin: 0;
@@ -122,9 +122,13 @@ export const StyledCheckbox = styled<
  * Basic checkbox input
  */
 const Checkbox = ({
-  checked,
+  checked = false,
   disabled = false,
+  forwardedRefs,
+  id,
+  onBlur,
   onChange,
+  onFocus,
   'aria-label': ariaLabel,
   value,
   color,
@@ -133,20 +137,29 @@ const Checkbox = ({
 }: {
   checked: boolean;
   disabled?: boolean;
+  forwardedRefs?: RefObject<HTMLInputElement>[];
+  id?: string;
   size?: StyledCheckboxStyles;
+  onBlur?: (e: any | void) => any | void;
   onChange: (e: any | void) => any | void;
+  onFocus?: (e: any | void) => any | void;
   'aria-label': string;
   value: string | number;
   color?: string;
 }) => {
-  const HiddenCheckboxRef = React.createRef<HTMLInputElement>();
+  const checkboxRef = forwardedRefs?.[0] || React.createRef<HTMLInputElement>();
+  const HiddenCheckboxRef = forwardedRefs?.[1] || React.createRef<HTMLInputElement>();
+
+  const eventHandler = (fn) => (event) => {
+    fn?.(event);
+    fn?.(value);
+  };
 
   return (
     <StyledCheckbox
       data-value={value}
       checked={checked}
       disabled={disabled}
-      onClick={onChange}
       color={color}
       size={size}
     >
@@ -155,16 +168,21 @@ const Checkbox = ({
         ref={HiddenCheckboxRef}
         checked={checked}
         disabled={disabled}
-        onChange={onChange}
+        id={id}
+        onBlur={eventHandler(onBlur)}
+        onChange={eventHandler(onChange)}
+        onFocus={eventHandler(onFocus)}
         aria-label={ariaLabel}
+        value={value}
       />
       <div
         className="checkbox"
-        onClick={e => {
-          if (document.activeElement !== HiddenCheckboxRef.current && HiddenCheckboxRef.current) {
-            HiddenCheckboxRef.current.focus();
+        onClick={(event) => {
+          if (event.target !== HiddenCheckboxRef.current && HiddenCheckboxRef.current) {
+            HiddenCheckboxRef.current.click();
           }
         }}
+        ref={checkboxRef}
       />
     </StyledCheckbox>
   );

--- a/uikit/form/Checkbox/index.tsx
+++ b/uikit/form/Checkbox/index.tsx
@@ -150,11 +150,6 @@ const Checkbox = ({
   const checkboxRef = forwardedRefs?.[0] || React.createRef<HTMLInputElement>();
   const HiddenCheckboxRef = forwardedRefs?.[1] || React.createRef<HTMLInputElement>();
 
-  const eventHandler = (fn) => (event) => {
-    fn?.(event);
-    fn?.(value);
-  };
-
   return (
     <StyledCheckbox
       data-value={value}
@@ -169,9 +164,9 @@ const Checkbox = ({
         checked={checked}
         disabled={disabled}
         id={id}
-        onBlur={eventHandler(onBlur)}
-        onChange={eventHandler(onChange)}
-        onFocus={eventHandler(onFocus)}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={onFocus}
         aria-label={ariaLabel}
         value={value}
       />

--- a/uikit/form/FormCheckbox/index.tsx
+++ b/uikit/form/FormCheckbox/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { ReactNode, useContext } from 'react';
+import React, { ReactNode, useContext, useRef, useState } from 'react';
 
 import { css, UikitTheme } from '../../';
 import Icon from '../../Icon';
@@ -36,29 +36,66 @@ const FormCheckbox = ({
   checked?: boolean;
   children: ReactNode;
   disabled?: boolean;
-  onChange?: (any) => any;
   error?: boolean;
+  onBlur?: (e: any) => any;
+  onChange?: (e: any) => any;
+  onFocus?: (e: any) => any;
   required?: boolean;
   value?: string;
 }) => {
+  const [isFocused, setIsFocused] = useState(false);
   const theme: UikitTheme = useTheme();
+  const checkboxRef = useRef<HTMLInputElement>();
+  const hiddenCheckboxRef = useRef<HTMLInputElement>();
   const { onChange = props.onChange, isChecked } = useContext(RadioCheckContext);
+
   const {
     disabled = props.disabled,
     error = props.error,
+    focused,
+    handleBlur = props.onBlur,
+    handleFocus = props.onFocus,
     required = props.required,
   } = React.useContext(FormControlContext);
 
-  const onClick = () => onChange(value);
+  const onBlur = (event) => {
+    if (!(checkboxRef.current === event.target || hiddenCheckboxRef.current === event.target)) {
+      setIsFocused(false);
+      handleBlur?.(event);
+    }
+  };
+
+  const onClick = (event) => {
+    if (!(checkboxRef.current === event.target || hiddenCheckboxRef.current === event.target)) {
+      checkboxRef.current.click();
+    }
+  };
+
+  const onFocus = (event) => {
+    if (!(checkboxRef.current === event.target || hiddenCheckboxRef.current === event.target)) {
+      setIsFocused(true);
+      handleFocus?.(event);
+    }
+  };
+
   const calcChecked = typeof isChecked === 'function' ? isChecked(value) : isChecked || checked;
 
   return (
-    <RadioCheckboxWrapper checked={calcChecked} disabled={disabled} error={error} onClick={onClick}>
+    <RadioCheckboxWrapper
+      checked={calcChecked}
+      disabled={disabled}
+      error={error}
+      focused={focused || isFocused}
+      onClick={onClick}
+    >
       <Checkbox
         value={value}
         checked={calcChecked}
         disabled={disabled}
+        forwardedRefs={[checkboxRef, hiddenCheckboxRef]}
+        onBlur={onBlur}
         onChange={onChange}
+        onFocus={onFocus}
         aria-label={props['aria-label']}
       />
 

--- a/uikit/form/FormCheckbox/index.tsx
+++ b/uikit/form/FormCheckbox/index.tsx
@@ -53,15 +53,16 @@ const FormCheckbox = ({
     disabled = props.disabled,
     error = props.error,
     focused,
-    handleBlur = props.onBlur,
-    handleFocus = props.onFocus,
+    handleBlur,
+    handleFocus,
     required = props.required,
   } = React.useContext(FormControlContext);
 
   const onBlur = (event) => {
     if (checkboxRef.current === event.target || hiddenCheckboxRef.current === event.target) {
       setIsFocused(false);
-      handleBlur?.(event);
+      handleBlur?.();
+      props.onBlur?.(event);
     }
   };
 
@@ -74,7 +75,8 @@ const FormCheckbox = ({
   const onFocus = (event) => {
     if (checkboxRef.current === event.target || hiddenCheckboxRef.current === event.target) {
       setIsFocused(true);
-      handleFocus?.(event);
+      handleFocus?.();
+      props.onFocus?.(event);
     }
   };
 

--- a/uikit/form/FormCheckbox/index.tsx
+++ b/uikit/form/FormCheckbox/index.tsx
@@ -59,7 +59,7 @@ const FormCheckbox = ({
   } = React.useContext(FormControlContext);
 
   const onBlur = (event) => {
-    if (!(checkboxRef.current === event.target || hiddenCheckboxRef.current === event.target)) {
+    if (checkboxRef.current === event.target || hiddenCheckboxRef.current === event.target) {
       setIsFocused(false);
       handleBlur?.(event);
     }
@@ -72,7 +72,7 @@ const FormCheckbox = ({
   };
 
   const onFocus = (event) => {
-    if (!(checkboxRef.current === event.target || hiddenCheckboxRef.current === event.target)) {
+    if (checkboxRef.current === event.target || hiddenCheckboxRef.current === event.target) {
       setIsFocused(true);
       handleFocus?.(event);
     }

--- a/uikit/form/FormCheckbox/stories.tsx
+++ b/uikit/form/FormCheckbox/stories.tsx
@@ -18,7 +18,7 @@
  */
 
 import { storiesOf } from '@storybook/react';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import FormCheckbox from '.';
 import { boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
@@ -35,12 +35,26 @@ const createKnobs = () => {
     checked,
     disabled,
     error,
+    onBlur: () => {
+      if (disabled) {
+        action('checkbox blurred while disabled')(value, checked);
+      } else {
+        action('checkbox blurred, is it checked')(value, checked);
+      }
+    },
     onChange: () => {
       if (disabled) {
         action('checkbox clicked while disabled')(value, checked);
       } else {
-        action('checkbox clicked')(value, !checked);
+        action('checkbox clicked, is it checked')(value, !checked);
         setChecked(!checked);
+      }
+    },
+    onFocus: () => {
+      if (disabled) {
+        action('checkbox focused while disabled')(value, checked);
+      } else {
+        action('checkbox focused, is it checked')(value, checked);
       }
     },
     required,
@@ -61,10 +75,13 @@ const CheckboxStories = storiesOf(`${__dirname}`, module)
   ))
   .add('Checkbox Group', () => {
     const [selectedItems, setSelected] = useState(new Set([]));
-    const isChecked = (item) => selectedItems.has(item);
-    const onChange = (value) => {
+    const isChecked = useCallback((item) => selectedItems.has(item), [selectedItems]);
+    const onChange = (event) => {
+      const value = event.target.defaultValue;
+
       selectedItems.has(value) ? selectedItems.delete(value) : selectedItems.add(value);
       const newSelectedItems = new Set(selectedItems);
+
       action('checkbox clicked')(value, Array.from(newSelectedItems));
       setSelected(newSelectedItems);
     };

--- a/uikit/form/FormControl/FormControlContext.tsx
+++ b/uikit/form/FormControl/FormControlContext.tsx
@@ -23,7 +23,7 @@ const FormControlContext = React.createContext<{
   disabled?: boolean;
   error?: string | boolean;
   focused?: boolean;
-  handleFocus?: () => void;
+  handleFocus?: () => any;
   handleBlur?: () => any;
   required?: boolean;
 }>({});

--- a/uikit/form/FormControl/index.tsx
+++ b/uikit/form/FormControl/index.tsx
@@ -66,7 +66,9 @@ const FormControl = React.forwardRef<
     handleFocus: () => {
       setFocused(true);
     },
-    handleBlur: () => setFocused(false),
+    handleBlur: () => {
+      setFocused(false);
+    },
   };
 
   return (

--- a/uikit/form/common.tsx
+++ b/uikit/form/common.tsx
@@ -84,9 +84,10 @@ export const StyledInputWrapper = styled<'div', StyledInputWrapperProps>('div')`
 `;
 
 type RadioCheckboxWrapperProps = {
-  error?: boolean | string;
-  disabled?: boolean;
   checked?: boolean;
+  disabled?: boolean;
+  error?: boolean | string;
+  focused?: boolean;
 };
 export const RadioCheckboxWrapper = styled<'div', RadioCheckboxWrapperProps>('div')`
   display: flex;
@@ -116,6 +117,11 @@ export const RadioCheckboxWrapper = styled<'div', RadioCheckboxWrapperProps>('di
 
   &:hover {
     cursor: pointer;
+  }
+
+  ${({ focused, theme }) => focused && `box-shadow: 0px 0px 4px 0px ${theme.colors.secondary_1};`}
+  &:focus {
+    box-shadow: 0px 0px 4px 0px ${({ theme }) => theme.colors.secondary_1};
   }
 `;
 


### PR DESCRIPTION
**Description of changes**

Enables using the checkboxes' `blur` and `focus` events, and styles the `FormCheckbox` component accordingly, even when used inside a `FormControl`. 

Had to jump through a few hoops and loops because of the outdated version of React: `event.stopPropagation()` is basically useless in some scenarios. See this issue for more context. https://github.com/facebook/react/issues/4335#issuecomment-671487964

Can be tested here: https://feature-formcheckbox-focus-blur--argo-ui-storybook.netlify.app/?path=/story/uikit-form-formcheckbox--default

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
