### PR TITLE
restore repository facets grey tags tone

### DIFF
--- a/uikit/Tag/index.tsx
+++ b/uikit/Tag/index.tsx
@@ -61,14 +61,14 @@ const Tag = styled<'div', { variant?: keyof typeof TAG_VARIANTS }>('div')`
   border-radius: 8px;
   background-color: ${({ theme, variant = 'INFO' }) =>
     ({
-      [TAG_VARIANTS.DISABLED]: theme.colors.grey_2,
+      [TAG_VARIANTS.DISABLED]: theme.colors.primary_2,
       [TAG_VARIANTS.EDITABLE]: theme.colors.accent2,
       [TAG_VARIANTS.ERROR]: theme.colors.error,
       [TAG_VARIANTS.WARNING]: theme.colors.warning,
       [TAG_VARIANTS.INFO]: theme.colors.secondary,
+      [TAG_VARIANTS.NEUTRAL]: theme.colors.grey_2,
       [TAG_VARIANTS.SUCCESS]: theme.colors.accent1_dimmed,
       [TAG_VARIANTS.UPDATE]: theme.colors.accent3_dark,
-      [TAG_VARIANTS.NEUTRAL]: theme.colors.primary_2,
       [TAG_VARIANTS.HIGHLIGHT]: theme.colors.secondary_2,
     }[variant])};
   color: ${({ variant = 'INFO' }) =>

--- a/uikit/package.release.json
+++ b/uikit/package.release.json
@@ -1,6 +1,6 @@
 {
   "name": "@icgc-argo/uikit",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/icgc-argo/platform-ui/tree/develop/uikit"


### PR DESCRIPTION
**Description of changes**

Greys got mixed up. This restores them. Bumped UiKit version to prep for hotfix release.

![image](https://user-images.githubusercontent.com/2107110/120233797-95a28780-c224-11eb-9db7-c60451f5bb0b.png)


**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [x] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
