### PR TITLE
improve event handling for Select and Multiselect

### DIFF
--- a/uikit/form/MultiSelect/index.tsx
+++ b/uikit/form/MultiSelect/index.tsx
@@ -194,6 +194,7 @@ function Highlight({ string, searchText }) {
 
 const MultiSelect: React.ComponentType<{
   ['aria-label']: string;
+  id?: string;
   /* Name of the Input */
   name?: string;
 
@@ -227,6 +228,7 @@ const MultiSelect: React.ComponentType<{
   inputProps?: InputHTMLAttributes<HTMLInputElement>;
   error?: boolean | string;
 }> = ({
+  id,
   name,
   value = [],
   children,
@@ -258,9 +260,13 @@ const MultiSelect: React.ComponentType<{
     const newValue = single ? [child.props.value] : uniq([...value, child.props.value]);
 
     event.target = {
-      value: newValue,
+      id,
       name,
+      tagName: 'MULTISELECT',
+      type: `select-${single ? 'one' : 'multiple'}`,
+      value: newValue,
     };
+
     setSearchString('');
     onChange(event, child);
   };
@@ -294,8 +300,11 @@ const MultiSelect: React.ComponentType<{
     const newValue = single ? [searchString] : uniq([...value, searchString]);
 
     event.target = {
-      value: newValue,
+      id,
       name,
+      tagName: 'MULTISELECT',
+      type: `select-${single ? 'one' : 'multiple'}`,
+      value: newValue,
     };
 
     setSearchString('');
@@ -365,9 +374,13 @@ const MultiSelect: React.ComponentType<{
   const handleSelectedItemClick = (item) => (event) => {
     event.persist();
     event.target = {
-      value: without([...value], item.value),
+      id,
       name,
+      tagName: 'MULTISELECT',
+      type: `select-${single ? 'one' : 'multiple'}`,
+      value: without([...value], item.value),
     };
+
     onChange(event, item);
   };
 
@@ -424,7 +437,7 @@ const MultiSelect: React.ComponentType<{
         <Input
           autoComplete="off"
           aria-label={ariaLabel}
-          id={`${name}-multiselect`}
+          id={id || `${name}-multiselect`}
           value={searchString}
           onChange={handleInputChange}
           onKeyDown={handleInputKeyDown}

--- a/uikit/package.release.json
+++ b/uikit/package.release.json
@@ -1,6 +1,6 @@
 {
   "name": "@icgc-argo/uikit",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/icgc-argo/platform-ui/tree/develop/uikit"


### PR DESCRIPTION
**Description of changes**

Dealing blur/focus behaviours at DACO, noticed there were some iffy behaviours in these two components when not using a mouse (tab + arrow keys).
As they are part of a same category, I've chosen to fix them together. No visible changes, and functionality should appear the same when using these at `platform-ui`.

PR Storybook: https://fix-selects--argo-ui-storybook.netlify.app/?path=/story/uikit-form-select--basic

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
