### PR TITLE
decouple emotion codependency

### DIFF
--- a/uikit/AppBar/DropdownMenu.tsx
+++ b/uikit/AppBar/DropdownMenu.tsx
@@ -18,8 +18,8 @@
  */
 
 import React, { LiHTMLAttributes } from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
-import css from '@emotion/css';
 import clsx from 'clsx';
 
 const Ul = styled('ul')`

--- a/uikit/AppBar/styledComponents.tsx
+++ b/uikit/AppBar/styledComponents.tsx
@@ -17,10 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
+import React from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import { withProps } from 'recompose';
 
 import Typography from '../Typography';

--- a/uikit/Button/index.tsx
+++ b/uikit/Button/index.tsx
@@ -17,8 +17,9 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
-import { css } from 'uikit';
+import React from 'react';
+import { css } from '@emotion/core';
+
 import Icon from '../Icon';
 import useTheme from '../utils/useTheme';
 import { BUTTON_VARIANTS, BUTTON_SIZES } from './constants';

--- a/uikit/Button/stories.tsx
+++ b/uikit/Button/stories.tsx
@@ -17,14 +17,16 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { radios, boolean, text } from '@storybook/addon-knobs';
-import React from 'react';
+import { css } from '@emotion/core';
+
 import Button from '.';
 import { asyncDummyFunc, placeholderImageURLRoot } from '../testUtil';
 import Icon from 'uikit/Icon';
-import { css } from 'uikit';
+
 import { BUTTON_VARIANTS, BUTTON_SIZES } from './constants';
 
 const dummyClick = action('Clicked!');

--- a/uikit/ClipboardCopyField/index.tsx
+++ b/uikit/ClipboardCopyField/index.tsx
@@ -17,11 +17,13 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
 import { StyledInputWrapper, INPUT_STATES, INPUT_SIZES } from 'uikit/form/common';
 import Button from 'uikit/Button';
 import Typography from 'uikit/Typography';
-import { css, styled } from '..';
 import Tag, { TAG_VARIANTS } from 'uikit/Tag';
 import Icon from 'uikit/Icon';
 

--- a/uikit/Container/index.tsx
+++ b/uikit/Container/index.tsx
@@ -17,9 +17,12 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import isPropValid from '@emotion/is-prop-valid';
+
 import color from 'color';
-import { css, isPropValid, styled } from '..';
 import useTheme from '../utils/useTheme';
 import DnaLoader from '../DnaLoader';
 

--- a/uikit/ContentPlaceholder/index.tsx
+++ b/uikit/ContentPlaceholder/index.tsx
@@ -18,9 +18,11 @@
  */
 
 import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
 import noDataSvg from 'uikit/assets/noData.svg';
 import Typography from '../Typography';
-import { css, styled } from '..';
 
 const Container = styled('div')`
   display: flex;

--- a/uikit/DropdownButton/index.tsx
+++ b/uikit/DropdownButton/index.tsx
@@ -18,12 +18,12 @@
  */
 
 import * as React from 'react';
+import { css, SerializedStyles } from '@emotion/core';
+
 import Typography from 'uikit/Typography';
 import Button from 'uikit/Button';
-import { css } from 'uikit';
 import useClickAway from 'uikit/utils/useClickAway';
 import { useTheme } from 'uikit/ThemeProvider';
-import { SerializedStyles } from '@emotion/core';
 
 const MenuItem: typeof Typography = (props) => {
   const theme = useTheme();

--- a/uikit/FileSelectButton/index.tsx
+++ b/uikit/FileSelectButton/index.tsx
@@ -18,8 +18,9 @@
  */
 
 import React from 'react';
+import { css } from '@emotion/core';
+
 import Button from 'uikit/Button';
-import { css } from 'uikit';
 
 type FileSelectButtonProps = Omit<React.ComponentProps<typeof Button>, 'onClick'> & {
   inputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>;
@@ -46,7 +47,7 @@ const FileSelectButton: React.ComponentType<FileSelectButtonProps> = ({
         type="file"
         ref={fileInputRef}
         accept=".tsv"
-        onChange={e => {
+        onChange={(e) => {
           onFilesSelect(e.target.files);
         }}
         css={css`

--- a/uikit/Icon/InteractiveIcon/index.tsx
+++ b/uikit/Icon/InteractiveIcon/index.tsx
@@ -18,10 +18,11 @@
  */
 
 import React from 'react';
+import { css } from '@emotion/core';
+
 import Icon from 'uikit/Icon';
 import Tooltip, { TooltipProps } from 'uikit/Tooltip';
 import { useTheme } from 'uikit/ThemeProvider';
-import { css } from 'uikit';
 
 // dims corresponding hex code for a 25% dim
 const dimColour = (hex: string) => `${hex}BF`;

--- a/uikit/Icon/icons/collection/mail.tsx
+++ b/uikit/Icon/icons/collection/mail.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { css } from '../../..';
+import { css } from '@emotion/core';
 
 export default {
   title: 'Mail',

--- a/uikit/Icon/icons/collection/trash.tsx
+++ b/uikit/Icon/icons/collection/trash.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { css } from '../../..';
+import { css } from '@emotion/core';
 
 export default {
   title: 'Trash',

--- a/uikit/InstructionBox/index.tsx
+++ b/uikit/InstructionBox/index.tsx
@@ -17,11 +17,12 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
 import { Col, Row, ScreenClassRender } from 'react-grid-system';
-import { css } from 'uikit';
 import { useTheme } from 'uikit/ThemeProvider';
-import styled from '@emotion/styled-base';
 
 const InstructionBox = ({
   steps,
@@ -57,7 +58,7 @@ const InstructionBox = ({
         `;
   return (
     <ScreenClassRender
-      render={size => (
+      render={(size) => (
         <Col>
           <Row nogutter>
             {steps.map((step, i) => (

--- a/uikit/Link/index.tsx
+++ b/uikit/Link/index.tsx
@@ -18,8 +18,8 @@
  */
 
 import React, { AnchorHTMLAttributes } from 'react';
-import PropTypes from 'prop-types';
-import { styled, css } from '..';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 
 type LinkVariant = 'INLINE' | 'BLOCK';
 export type HyperLinkProps = {

--- a/uikit/Modal/index.tsx
+++ b/uikit/Modal/index.tsx
@@ -19,7 +19,9 @@
 
 import React from 'react';
 import Color from 'color';
-import { styled, css } from '..';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
 import Typography from '../Typography';
 import Button from '../Button';
 import Icon from '../Icon';

--- a/uikit/PercentageBar/index.tsx
+++ b/uikit/PercentageBar/index.tsx
@@ -18,13 +18,13 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
 import useTheme from '../utils/useTheme';
 import Typography from '../Typography';
 import Icon from '../Icon';
-import { css } from '../';
 
-const VAlignedText = props => (
+const VAlignedText = (props) => (
   <Typography
     variant="data"
     component="span"
@@ -66,7 +66,8 @@ const PercentageBar = ({
       `}
     >
       <VAlignedText>
-        {nom.toLocaleString()} <Icon name="slash" height="15px" fill="grey_2" /> {denom.toLocaleString()}
+        {nom.toLocaleString()} <Icon name="slash" height="15px" fill="grey_2" />{' '}
+        {denom.toLocaleString()}
       </VAlignedText>
       <VAlignedText
         css={css`

--- a/uikit/Progress/index.tsx
+++ b/uikit/Progress/index.tsx
@@ -17,10 +17,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
-import { styled } from '../';
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
 import Icon from '../Icon';
-import { css } from '..';
 import { HtmlAttributes } from 'csstype';
 
 export type ProgressStatus = 'success' | 'error' | 'pending' | 'disabled' | 'locked';
@@ -39,7 +40,7 @@ export const PROGRESS_STATUS: {
   LOCKED: 'locked',
 };
 
-const Triangle = props => css`
+const Triangle = (props) => css`
   content: ' ';
   display: block;
   position: relative;

--- a/uikit/SystemAlert/index.tsx
+++ b/uikit/SystemAlert/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { css } from '@emotion/core';
+
 import { ThemeColorNames } from '../theme/types';
 import Typography from 'uikit/Typography';
 import Icon from 'uikit/Icon';
 import { UikitIconNames } from 'uikit/Icon/icons';
-import { css } from 'uikit';
 import { Col, Row } from 'react-grid-system';
 import { useTheme } from 'uikit/ThemeProvider';
 

--- a/uikit/Table/SimpleTable/index.tsx
+++ b/uikit/Table/SimpleTable/index.tsx
@@ -17,7 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { css } from 'uikit';
+import { css } from '@emotion/core';
+
 import Table from 'uikit/Table';
 
 type MappedTableData = Array<{ key: string; val: any }>;

--- a/uikit/TitleBorder/index.tsx
+++ b/uikit/TitleBorder/index.tsx
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { css, styled } from '..';
+import styled from '@emotion/styled';
 import React from 'react';
 import defaultTheme from 'uikit/theme/defaultTheme';
 

--- a/uikit/Tooltip/index.tsx
+++ b/uikit/Tooltip/index.tsx
@@ -19,10 +19,10 @@
 
 // @flow
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 import { Tooltip as ReactTippy } from 'react-tippy';
 
-import { css, styled } from '..';
 import useTheme from '../utils/useTheme';
 import { Global } from '@emotion/core';
 import { merge } from 'lodash';

--- a/uikit/VerticalTabs/index.tsx
+++ b/uikit/VerticalTabs/index.tsx
@@ -24,8 +24,9 @@ import React, {
   ReactElement,
   MouseEventHandler,
 } from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 import { useTheme } from '../ThemeProvider';
-import { css, styled } from '..';
 import Typography from 'uikit/Typography';
 import Tag from 'uikit/Tag';
 import FocusWrapper from 'uikit/FocusWrapper';

--- a/uikit/VerticalTabs/stories.tsx
+++ b/uikit/VerticalTabs/stories.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { css } from '..';
+import { css } from '@emotion/core';
 import VerticalTabs from '.';
 
 const LoremTooltip = (

--- a/uikit/form/FormCheckbox/index.tsx
+++ b/uikit/form/FormCheckbox/index.tsx
@@ -18,8 +18,9 @@
  */
 
 import React, { ReactNode, useContext, useRef, useState } from 'react';
+import { css } from '@emotion/core';
 
-import { css, UikitTheme } from '../../';
+import { UikitTheme } from '../../';
 import Icon from '../../Icon';
 import { useTheme } from '../../ThemeProvider';
 import Checkbox from '../Checkbox';

--- a/uikit/form/FormControl/index.tsx
+++ b/uikit/form/FormControl/index.tsx
@@ -18,8 +18,9 @@
  */
 
 import React from 'react';
+import { css } from '@emotion/core';
+
 import FormControlContext from './FormControlContext';
-import { styled, css } from 'uikit';
 
 const FormControl = React.forwardRef<
   HTMLElement,

--- a/uikit/notifications/Notification/index.tsx
+++ b/uikit/notifications/Notification/index.tsx
@@ -19,8 +19,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 
-import { styled, css } from '../../';
 import Typography, { TypographyVariant } from '../../Typography';
 import Icon from '../../Icon';
 import FocusWrapper from '../../FocusWrapper';
@@ -40,7 +40,7 @@ export type NotificationInteractionEvent = 'CLOSE' | 'ACTION' | 'DISMISS';
 export type NotificationInteraction = 'CLOSE' | 'ACTION_DISMISS' | 'NONE';
 export type NotificationSize = 'MD' | 'SM';
 
-const getDefaultInteractionType = variant =>
+const getDefaultInteractionType = (variant) =>
   ({
     [NOTIFICATION_VARIANTS.INFO]: NOTIFICATION_INTERACTION.CLOSE,
     [NOTIFICATION_VARIANTS.SUCCESS]: NOTIFICATION_INTERACTION.ACTION_DISMISS,
@@ -102,7 +102,7 @@ const Notification = ({
   contentProps?: React.ComponentProps<typeof NotificationBodyContainer>;
 }) => {
   const theme = useTheme();
-  const dispatchEvent = eventType => e => onInteraction({ type: eventType, event: e });
+  const dispatchEvent = (eventType) => (e) => onInteraction({ type: eventType, event: e });
   const titleTypographyVariant = {
     [NOTIFICATION_SIZES.MD]: 'subtitle2' as TypographyVariant,
     [NOTIFICATION_SIZES.SM]: 'paragraph' as TypographyVariant,

--- a/uikit/notifications/Notification/styledComponents.tsx
+++ b/uikit/notifications/Notification/styledComponents.tsx
@@ -17,7 +17,9 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { styled, css } from '../..';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
 import { NOTIFICATION_VARIANTS, NotificationVariant } from '.';
 import FocusWrapper from '../../FocusWrapper';
 


### PR DESCRIPTION
**Description of changes**

It seems in an attempt to ensure the UiKits components were locked into a specific version of Emotion, the library doesn't respond correctly to their babel plugin settings.
This is creating styling issues when integrating the UiKit into another app, which may discourage its usage.

This PR ensures the components import the Emotion utilities directly from the package, rather than from a centralised import at the root of the library.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
