### PR TITLE
Feature/textarea counter button link

### DIFF
--- a/.storybook/PropTypesTable/index.tsx
+++ b/.storybook/PropTypesTable/index.tsx
@@ -24,7 +24,7 @@ import ReactTableContainer from './ReactTableContainer';
 export default ({ propDefinitions }) => (
   <ReactTableContainer>
     <ReactTable
-      minRows={0}
+      minRows={1}
       showPagination={false}
       data={propDefinitions}
       columns={[

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -50,6 +50,7 @@ module.exports = async ({ config }) => {
                 '@emotion/babel-preset-css-prop',
                 {
                   autoLabel: true,
+                  labelFormat: 'Uikit-[local]',
                 },
               ],
             ],

--- a/uikit/.babelrc.json
+++ b/uikit/.babelrc.json
@@ -11,7 +11,8 @@
     [
       "@emotion/babel-preset-css-prop",
       {
-        "autoLabel": true
+        "autoLabel": true,
+        "labelFormat": "Uikit-[local]"
       }
     ]
   ],

--- a/uikit/Button/constants.tsx
+++ b/uikit/Button/constants.tsx
@@ -20,10 +20,12 @@
 import { ButtonVariant, ButtonSize } from './types';
 
 export const BUTTON_VARIANTS: {
+  LINK: ButtonVariant;
   PRIMARY: ButtonVariant;
   SECONDARY: ButtonVariant;
   TEXT: ButtonVariant;
 } = Object.freeze({
+  LINK: 'link',
   PRIMARY: 'primary',
   SECONDARY: 'secondary',
   TEXT: 'text',

--- a/uikit/Button/index.tsx
+++ b/uikit/Button/index.tsx
@@ -101,20 +101,7 @@ const Button = React.forwardRef<
         className={className}
         id={id}
       >
-        <div
-          css={css`
-            display: ${shouldShowLoading ? 'block' : 'none'};
-          `}
-        >
-          <LoaderComp variant={variant} theme={theme} />
-        </div>
-        <div
-          css={css`
-            display: ${shouldShowLoading ? 'none' : 'block'};
-          `}
-        >
-          {children}
-        </div>
+        {shouldShowLoading ? <LoaderComp variant={variant} theme={theme} /> : children}
       </StyledButton>
     );
   },

--- a/uikit/Button/styled.tsx
+++ b/uikit/Button/styled.tsx
@@ -21,52 +21,69 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import FocusWrapper from 'uikit/FocusWrapper';
 
+import { BUTTON_VARIANTS } from './constants';
+import { ButtonSize, ButtonVariant } from './types';
+
 const StyledButton = styled<
   typeof FocusWrapper,
   {
-    size: 'sm' | 'md';
-    variant: 'primary' | 'secondary' | 'text';
+    size: ButtonSize;
+    variant: ButtonVariant;
     disabled: boolean;
   }
 >(FocusWrapper)`
   ${({ theme }) => css(theme.typography.default)};
-  transition: all 0.25s;
-  display: flex;
   align-items: center;
+  border: none;
+  box-shadow: none;
+  display: flex;
+  font-weight: 600;
   justify-content: center;
   outline: none;
-  box-shadow: none;
-  border: none;
-  border-radius: 100px;
-  font-weight: 600;
   text-transform: uppercase;
-  border-style: solid;
+  transition: all 0.25s;
 
   color: ${({ theme, variant }) => theme.button.textColors[variant].default};
-  background-color: ${({ theme, variant }) => theme.button.colors[variant].default};
-  border-color: ${({ theme, variant }) => theme.button.borderColors[variant].default};
-  border-width: ${({ theme, size }) => theme.button.borderWeights[size]};
-  padding: ${({ theme, size }) => theme.button.paddings[size]};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   font-size: ${({ theme, size }) => theme.button.fontSizes[size]};
 
-  &:focus {
-    background-color: ${({ theme, variant }) => theme.button.colors[variant].focus};
-  }
-
-  &:hover {
-    background-color: ${({ theme, variant }) => theme.button.colors[variant].hover};
-    border-color: ${({ theme, variant }) => theme.button.borderColors[variant].hover};
-  }
-
-  &:active {
-    background-color: ${({ theme, variant }) => theme.button.colors[variant].active};
-    border-color: ${({ theme, variant }) => theme.button.borderColors[variant].active};
-  }
   &:disabled {
-    background-color: ${({ theme, variant }) => theme.button.colors[variant].disabled};
-    border-color: ${({ theme, variant }) => theme.button.borderColors[variant].disabled};
     color: ${({ theme, variant }) => theme.button.textColors[variant].disabled};
   }
+
+  ${({ size, theme, variant }) =>
+    variant === BUTTON_VARIANTS.LINK
+      ? `
+        &:hover:not(:disabled) {
+          color: ${theme.button.textColors[variant].hover};
+        }
+      `
+      : `
+        background-color: ${theme.button.colors[variant].default};
+        border-color: ${theme.button.borderColors[variant].default};
+        border-radius: 100px;
+        border-style: solid;
+        border-width: ${theme.button.borderWeights[size]};
+        padding: ${theme.button.paddings[size]};
+        
+        &:focus {
+          background-color: ${theme.button.colors[variant].focus};
+        }
+
+        &:hover {
+          background-color: ${theme.button.colors[variant].hover};
+          border-color: ${theme.button.borderColors[variant].hover};
+        }
+
+        &:active {
+          background-color: ${theme.button.colors[variant].active};
+          border-color: ${theme.button.borderColors[variant].active};
+        }
+        
+        &:disabled {
+          background-color: ${theme.button.colors[variant].disabled};
+          border-color: ${theme.button.borderColors[variant].disabled};
+        }
+      `}
 `;
 export default StyledButton;

--- a/uikit/Button/types.ts
+++ b/uikit/Button/types.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-export type ButtonVariant = 'primary' | 'secondary' | 'text';
+export type ButtonVariant = 'link' | 'primary' | 'secondary' | 'text';
 export type ButtonSize = 'sm' | 'md';
 export type ButtonLoader = {
   text?: string;

--- a/uikit/Typography/index.tsx
+++ b/uikit/Typography/index.tsx
@@ -23,6 +23,7 @@ import memoize from 'lodash/memoize';
 
 import defaultTheme from '../theme/defaultTheme';
 import { useTheme } from '../ThemeProvider';
+import { css } from '@emotion/core';
 
 const defaultTags = {
   hero: 'h1',
@@ -84,7 +85,7 @@ const Typography: React.ComponentType<
     ? createDomComponent(domComponentName, componentMap, variant)
     : componentMap[variant];
   const StyledText = createStyledDomComponent(Component);
-  return <StyledText {...rest} bold={bold} color={color} />;
+  return <StyledText css={css``} {...rest} bold={bold} color={color} />;
 };
 
 export default Typography;

--- a/uikit/Typography/index.tsx
+++ b/uikit/Typography/index.tsx
@@ -23,7 +23,6 @@ import memoize from 'lodash/memoize';
 
 import defaultTheme from '../theme/defaultTheme';
 import { useTheme } from '../ThemeProvider';
-import { css } from '@emotion/core';
 
 const defaultTags = {
   hero: 'h1',
@@ -85,7 +84,7 @@ const Typography: React.ComponentType<
     ? createDomComponent(domComponentName, componentMap, variant)
     : componentMap[variant];
   const StyledText = createStyledDomComponent(Component);
-  return <StyledText css={css``} {...rest} bold={bold} color={color} />;
+  return <StyledText {...rest} bold={bold} color={color} />;
 };
 
 export default Typography;

--- a/uikit/form/FormControl/index.tsx
+++ b/uikit/form/FormControl/index.tsx
@@ -25,6 +25,7 @@ import FormControlContext from './FormControlContext';
 const FormControl = React.forwardRef<
   HTMLElement,
   {
+    className?: string;
     /**
      * The contents of the form control.
      */

--- a/uikit/form/Textarea/stories.tsx
+++ b/uikit/form/Textarea/stories.tsx
@@ -19,22 +19,81 @@
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { boolean, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import { boolean, number, radios, text } from '@storybook/addon-knobs';
 
 import Textarea from '.';
-import Icon from '../../Icon';
-import { action } from '@storybook/addon-actions';
 
-export default storiesOf(`${__dirname}`, module).add('Basic', () => {
-  return (
-    <Textarea
-      aria-label="demo-input"
-      onChange={action('onChange')}
-      onBlur={() => '[parent func]'}
-      placeholder={text('placeholder', '')}
-      disabled={boolean('disabled', false)}
-      error={boolean('error', false)}
-      rows={3}
-    />
-  );
-});
+export default storiesOf(`${__dirname}`, module).add(
+  'Basic',
+  () => {
+    const labelForCounterKnobs = 'Counter props';
+    const labelForTextAreaKnobs = 'Basic props';
+    const [value, setValue] = React.useState('');
+    const disabled = boolean('disabled', false, labelForTextAreaKnobs);
+
+    const onBlur = () => {
+      if (disabled) {
+        action('blurred while disabled')(value);
+      } else {
+        action('blurred')(value);
+      }
+    };
+    const onChange = (e) => {
+      const eventValue = e.target.value;
+      if (disabled) {
+        action('clicked while disabled')(eventValue);
+      } else {
+        action('clicked')(eventValue);
+        setValue(eventValue);
+      }
+    };
+    const onFocus = () => {
+      if (disabled) {
+        action('focused while disabled')(value);
+      } else {
+        action('focused')(value);
+      }
+    };
+
+    return (
+      <Textarea
+        aria-label="demo-input"
+        countDirection={radios(
+          'count direction',
+          { Ascending: 'asc', Descending: 'desc' },
+          'asc',
+          labelForCounterKnobs,
+        )}
+        countLimit={number(
+          'count limit',
+          0,
+          { max: Infinity, min: 0, range: true, step: 1 },
+          labelForCounterKnobs,
+        )}
+        countPosition={radios(
+          'count position',
+          { Left: 'left', Right: 'right' },
+          'right',
+          labelForCounterKnobs,
+        )}
+        countType={radios(
+          'count type',
+          { Characters: 'chars', Words: 'words' },
+          'chars',
+          labelForCounterKnobs,
+        )}
+        disabled={disabled}
+        error={boolean('error', false, labelForTextAreaKnobs)}
+        focused={boolean('focused', false, labelForTextAreaKnobs)}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={onFocus}
+        placeholder={text('placeholder', '', labelForTextAreaKnobs)}
+        truncate={boolean('truncate', false, labelForCounterKnobs)}
+        rows={number('rows', 3, { min: 1, step: 1 }, labelForTextAreaKnobs)}
+      />
+    );
+  },
+  {},
+);

--- a/uikit/form/Textarea/types.ts
+++ b/uikit/form/Textarea/types.ts
@@ -1,0 +1,46 @@
+export enum CountLabels {
+  chars = 'characters',
+  words = 'words',
+}
+
+export type CountPositions =
+  | 'absolute'
+  | 'absolute left'
+  | 'absolute right'
+  | 'left'
+  | 'left absolute'
+  | 'right'
+  | 'right absolute';
+
+export interface TextareaProps {
+  ['aria-label']: string;
+  /**
+   * Characterss/words given vs remaining
+   */
+  countDirection?: 'asc' | 'desc';
+  /**
+   * Limit should be greater than 0 to enable the counter
+   */
+  countLimit?: number;
+  /**
+   * Counter's position under the Textarea
+   */
+  countPosition?: CountPositions;
+  /**
+   * What to count: characters or words
+   */
+  countType?: 'chars' | 'words';
+  disabled?: boolean;
+  error?: boolean;
+  focused?: boolean;
+  /**
+   * Useful to correctly connect a label (using htmlFor)
+   */
+  id?: string;
+  resize?: 'none' | 'both' | 'horizontal' | 'vertical';
+  /**
+   * Disallows users to continue typing once a count limit has been reached (avoiding error)
+   */
+  truncate?: boolean;
+  value?: string;
+}

--- a/uikit/theme/defaultTheme/button.tsx
+++ b/uikit/theme/defaultTheme/button.tsx
@@ -18,6 +18,7 @@
  */
 
 import colors from './colors';
+
 export default {
   fontSizes: {
     sm: '12px',
@@ -32,16 +33,21 @@ export default {
     md: '6px 20px',
   },
   textColors: {
+    link: {
+      default: colors.accent2_dark,
+      disabled: colors.grey_1,
+      hover: colors.accent2,
+    },
     primary: {
       default: colors.white,
       disabled: colors.white,
     },
     secondary: {
-      default: '#523785',
+      default: colors.accent2_dark,
       disabled: colors.white,
     },
     text: {
-      default: '#523785',
+      default: colors.accent2_dark,
       disabled: '#d0d1d8',
     },
   },
@@ -50,8 +56,8 @@ export default {
       default: '#8258d0',
       hover: '#9e78e1',
       active: '#6d41bd',
-      focus: '#523785',
       disabled: colors.grey_disabled,
+      focus: colors.accent2_dark,
     },
     secondary: {
       default: colors.grey_1,


### PR DESCRIPTION
**Description of changes**

- Adds a character/word counter and correct focus/blur glow behaviour to the form Textarea component, as shown here:

![image](https://user-images.githubusercontent.com/2107110/121728631-88ef2080-cabb-11eb-9150-9fa1bb3cc2d3.png)

(Bonus: adds a whole lot of improvements to the Textarea story)

- Adds a `link`-looking variant to the button. (i.e. simple clickable text), because the existing `text` variant adds padding and a pill border on hover; and semantically speaking, a link should navigate whereas a button executes actions.

![image](https://user-images.githubusercontent.com/2107110/121729081-0fa3fd80-cabc-11eb-9181-6d24062735b4.png)


**Type of Change**

- [x] Bug
- [x] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [x] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
