### PR TITLE
Fix/relative path

### DIFF
--- a/uikit/notifications/Notification/styledComponents.tsx
+++ b/uikit/notifications/Notification/styledComponents.tsx
@@ -20,7 +20,7 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 
-import { NOTIFICATION_VARIANTS, NotificationVariant } from '.';
+import { NOTIFICATION_VARIANTS, NotificationVariant } from './';
 import FocusWrapper from '../../FocusWrapper';
 
 const getBackgroundColor = ({ theme, variant }: { theme?: any; variant: NotificationVariant }) =>


### PR DESCRIPTION
**Description of changes**

Silly babel is transpiling `'.'` into `'../..'` for some reason which seems to only be an issue when importing Uikit into other projects... My hunch is exporting the library to be used from `node_modules`, babel takes the project's root as reference to `tsconfig`s baseUrl (which I cannot confirm without tests), in contrast to platform-ui importing the components directly from a local folder, pre-transpilation.
Meaning, this issue may be present yet hidden in other Uikit Components.

This change ensures the path stays true for the Notifications/Banners when the library is exported.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
