### PR TITLE
Add EmbargoStage and ReleaseState facets

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -7,6 +7,12 @@ FEATURE_REPOSITORY_ENABLED=false
 FEATURE_LANDING_PAGE_STATS_ENABLED=false
 FEATURE_ACCESS_FACET_ENABLED=false
 
+# Feature flag for charts on program dashboard
+# (Completed Core Clinical Data & Molecular Data Summary)
+FEATURE_DASHBOARD_CHARTS_ENABLED=true
+
+FEATURE_FILE_ENTITY_ENABLED=true
+
 ######### Gateway API
 GATEWAY_API_ROOT=http://localhost:9000
 
@@ -40,8 +46,3 @@ TEST_GOOGLE_PASS= # user pass
 # For Storybook only
 STORYBOOK_GATEWAY_API_ROOT=http://localhost:9000
 
-# Feature flag for charts on program dashboard
-# (Completed Core Clinical Data & Molecular Data Summary)
-FEATURE_DASHBOARD_CHARTS_ENABLED=true
-
-FEATURE_FILE_ENTITY_ENABLED=true

--- a/components/pages/file-repository/FacetPanel/FILE_REPOSITORY_FACETS_QUERY.gql
+++ b/components/pages/file-repository/FacetPanel/FILE_REPOSITORY_FACETS_QUERY.gql
@@ -61,6 +61,18 @@ query FILE_REPOSITORY_FACETS_QUERY($filters: JSON) {
           doc_count
         }
       }
+      embargo_stage {
+        buckets {
+          key
+          doc_count
+        }
+      }
+      release_state {
+        buckets {
+          key
+          doc_count
+        }
+      }
     }
   }
 }

--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -16,8 +16,8 @@
  * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 import React, { useState, useEffect } from 'react';
+import { canReadSomeProgram, isDccMember } from 'global/utils/egoJwt';
 import Facet from 'uikit/Facet';
 import { MenuItem } from 'uikit/SubMenu';
 import { Input } from 'uikit/form';
@@ -82,12 +82,17 @@ const createPresetFacets = (
   displayNames: ReturnType<typeof useFileCentricFieldDisplayName>['data'],
 ): Array<FacetDetails> => [
   {
-    name: displayNames['release_stage'],
-    facetPath: FileFacetPath.release_stage,
+    name: displayNames['embargo_stage'],
+    facetPath: FileFacetPath.embargo_stage,
     variant: 'Tooltip',
-    esDocumentField: FileCentricDocumentField.release_stage,
-  } as FacetDetails,
-
+    esDocumentField: FileCentricDocumentField.embargo_stage,
+  },
+  {
+    name: displayNames['release_state'],
+    facetPath: FileFacetPath.release_state,
+    variant: 'Basic',
+    esDocumentField: FileCentricDocumentField.release_state,
+  },
   {
     name: displayNames['study_id'],
     facetPath: FileFacetPath.study_id,
@@ -225,25 +230,18 @@ const useIdSearchQuery = (
   });
 };
 
-// encapsulate conditional release stage facet logic
-const getReleaseStageFacet = (presetFacets: FacetDetails[], commonFacetProps) => {
-  const { FEATURE_ACCESS_FACET_ENABLED } = getConfig();
-  const { egoJwt } = useAuthContext();
-
-  if (FEATURE_ACCESS_FACET_ENABLED && !!egoJwt) {
-    const facet = presetFacets.find((f) => f.facetPath === FileFacetPath.release_stage);
-    const commonProps = commonFacetProps(facet);
-    return { releaseStageDetails: facet, releaseStageCommonProps: commonProps };
-  } else {
-    return { releaseStageDetails: null, releaseStageCommonProps: null };
-  }
-};
-
-export default () => {
+const FacetPanel = () => {
   const {
     data: fieldDisplayNames,
     loading: loadingFieldDisplayNames,
   } = useFileCentricFieldDisplayName();
+
+  const { FEATURE_ACCESS_FACET_ENABLED } = getConfig();
+  const { egoJwt, permissions } = useAuthContext();
+  const embargoStageEnabled =
+    FEATURE_ACCESS_FACET_ENABLED && !!egoJwt && canReadSomeProgram(permissions);
+
+  const releaseStateEnabled = FEATURE_ACCESS_FACET_ENABLED && !!egoJwt && isDccMember(permissions);
 
   const presetFacets = createPresetFacets(fieldDisplayNames);
   const [expandedFacets, setExpandedFacets] = React.useState(
@@ -281,17 +279,8 @@ export default () => {
 
   const debouncedSearchTerm = useDebounce(searchQuery, 500);
 
-  /**
-   * Order release stage options
-   * Removes invalid keys eg. '__missing__'
-   */
-  const orderReleaseStage = (options: FilterOption[]) => {
-    const order = ['OWN_PROGRAM', 'FULL_PROGRAMS', 'ASSOCIATE_PROGRAMS', 'PUBLIC_QUEUE', 'PUBLIC'];
-    return order.map((order) => options.find((option) => option.key === order)).filter(Boolean);
-  };
-
   const getOptions: GetAggregationResult = (facet) => {
-    return (aggregations[facet.facetPath] || { buckets: [] }).buckets.map((bucket) => ({
+    const options = (aggregations[facet.facetPath] || { buckets: [] }).buckets.map((bucket) => ({
       ...bucket,
       isChecked: inCurrentFilters({
         currentFilters: filters,
@@ -299,6 +288,15 @@ export default () => {
         dotField: facet.esDocumentField,
       }),
     }));
+
+    // Control ordering of options for specific facets
+    switch (facet.name) {
+      case 'embargo_stage':
+        const order = ['PROGRAM_ONLY', 'MEMBER_ACCESS', 'ASSOCIATE_ACCESS', 'PUBLIC'];
+        return order.map((order) => options.find((option) => option.key === order)).filter(Boolean);
+      default:
+        return options;
+    }
   };
 
   const { data: idSearchData, loading: idSearchLoading } = useIdSearchQuery(
@@ -436,12 +434,6 @@ export default () => {
     },
   });
 
-  // get release stage facet to show before search bar
-  const { releaseStageDetails, releaseStageCommonProps } = getReleaseStageFacet(
-    presetFacets,
-    commonFacetProps,
-  );
-
   return (
     <FacetContainer
       // using css to fade and disable because FacetContainer uses over-flow which causes the DNAloader to move with scroll and not cover all facets
@@ -460,24 +452,6 @@ export default () => {
           >
             Filters
           </Typography>
-        </FacetRow>
-        <FacetRow
-          css={css`
-            border-top: 1px solid ${theme.colors.grey_2};
-          `}
-        >
-          {releaseStageDetails && releaseStageCommonProps && (
-            <TooltipFacet
-              {...releaseStageCommonProps}
-              key={releaseStageDetails.name}
-              options={orderReleaseStage(getOptions(releaseStageDetails))}
-              countUnit={'files'}
-              onOptionToggle={onFacetOptionToggle(releaseStageDetails)}
-              onSelectAllOptions={onFacetSelectAllOptionsToggle(releaseStageDetails)}
-              parseDisplayValue={(key) => getDisplayName(releaseStageDetails.esDocumentField, key)}
-              tooltipContent={getTooltipContent(releaseStageDetails.name)}
-            />
-          )}
         </FacetRow>
         <FacetRow
           css={css`
@@ -579,8 +553,14 @@ export default () => {
         </FacetRow>
         {!loadingFieldDisplayNames &&
           presetFacets
-            // filter out facets that are shown before search bar
-            .filter((f) => f.facetPath !== FileFacetPath.release_stage)
+            // Conditionally filter embargo_stage facet
+            .filter((f) => {
+              return embargoStageEnabled || f.facetPath !== FileFacetPath.embargo_stage;
+            })
+            //Conditionally filter release_state facet
+            .filter((f) => {
+              return releaseStateEnabled || f.facetPath !== FileFacetPath.release_state;
+            })
             .map((facetDetails) => {
               const facetProps = commonFacetProps(facetDetails);
 
@@ -605,6 +585,18 @@ export default () => {
                       max={numberRangeFacetMax(facetDetails)}
                     />
                   )}
+                  {facetDetails.variant === 'Tooltip' && (
+                    <TooltipFacet
+                      {...facetProps}
+                      key={facetDetails.name}
+                      options={getOptions(facetDetails)}
+                      countUnit={'files'}
+                      onOptionToggle={onFacetOptionToggle(facetDetails)}
+                      onSelectAllOptions={onFacetSelectAllOptionsToggle(facetDetails)}
+                      parseDisplayValue={(key) => getDisplayName(facetDetails.esDocumentField, key)}
+                      tooltipContent={getTooltipContent(facetDetails.facetPath)}
+                    />
+                  )}
                 </FacetRow>
               );
             })}
@@ -613,3 +605,5 @@ export default () => {
     </FacetContainer>
   );
 };
+
+export default FacetPanel;

--- a/components/pages/file-repository/FacetPanel/types.ts
+++ b/components/pages/file-repository/FacetPanel/types.ts
@@ -14,7 +14,8 @@ export enum FileFacetPath {
   donors__specimens__specimen_type = 'donors__specimens__specimen_type',
   donors__specimens__specimen_tissue_source = 'donors__specimens__specimen_tissue_source',
   analysis__workflow__workflow_name = 'analysis__workflow__workflow_name',
-  release_stage = 'release_stage',
+  release_state = 'release_state',
+  embargo_stage = 'embargo_stage',
 }
 
 type BucketAggregation = {
@@ -64,6 +65,12 @@ export type FileRepoFacetsQueryData = {
         buckets: BucketAggregation[];
       };
       [FileFacetPath.analysis__workflow__workflow_name]: {
+        buckets: BucketAggregation[];
+      };
+      [FileFacetPath.release_state]: {
+        buckets: BucketAggregation[];
+      };
+      [FileFacetPath.embargo_stage]: {
         buckets: BucketAggregation[];
       };
     };

--- a/components/pages/file-repository/types.ts
+++ b/components/pages/file-repository/types.ts
@@ -15,7 +15,8 @@ export enum FileCentricDocumentField {
   file_type = 'file_type',
   object_id = 'object_id',
   study_id = 'study_id',
-  release_stage = 'release_stage',
+  embargo_stage = 'embargo_stage',
+  release_state = 'release_state',
 }
 
 export type FileRepositoryTSVColumn = {

--- a/components/pages/file-repository/utils/constants.tsx
+++ b/components/pages/file-repository/utils/constants.tsx
@@ -2,7 +2,7 @@ import { css } from 'uikit';
 import { FileCentricDocumentField, FileRepositoryTSVColumn } from '../types';
 
 export const tooltipContent: { [key: string]: React.ReactNode } = {
-  'Release Stage': (
+  embargo_stage: (
     <div
       css={css`
         margin: 5px;
@@ -24,17 +24,16 @@ export const tooltipContent: { [key: string]: React.ReactNode } = {
   ),
 };
 
-enum ReleaseStageDisplayNames {
-  OWN_PROGRAM = 'My Program Access',
-  FULL_PROGRAMS = 'Full Member Access',
-  ASSOCIATE_PROGRAMS = 'Associate Member Access',
-  PUBLIC_QUEUE = 'Queued for Release',
+enum EmbargoStageDisplayNames {
+  PROGRAM_ONLY = 'My Program Access',
+  MEMBER_ACCESS = 'Full Member Access',
+  ASSOCIATE_ACCESS = 'Associate Member Access',
   PUBLIC = 'Released to the Public',
 }
 
 // enums are real objects at runtime
 export const facetDisplayNames: { [key: string]: {} } = {
-  [FileCentricDocumentField.release_stage]: ReleaseStageDisplayNames,
+  [FileCentricDocumentField.embargo_stage]: EmbargoStageDisplayNames,
 };
 
 export const fileRepoTableTSVColumns: FileRepositoryTSVColumn[] = [

--- a/components/pages/file-repository/utils/index.ts
+++ b/components/pages/file-repository/utils/index.ts
@@ -239,7 +239,7 @@ export const toDisplayValue: (value: string, field?: string) => string = (value,
   return value;
 };
 
-export const getTooltipContent = (name: string): React.ReactNode => tooltipContent[name];
+export const getTooltipContent = (facetPath: string): React.ReactNode => tooltipContent[facetPath];
 
 export const getDisplayName = (facetName: string, fieldName: string): string =>
   facetDisplayNames[facetName]?.[fieldName];


### PR DESCRIPTION
**Description of changes**

Adds FacetPanel aggregation facets for Embargo Stage (Access Tier) and Release State.

Release State will only show for DCC Admin users.

NOTE: Cannot be merged until the data sources in dev/qa have been updated with these fields.

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [X] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [ ] Connected ticket to PR
