### PR TITLE
fix sticky values in Uikit Select

### DIFF
--- a/uikit/form/Select/index.tsx
+++ b/uikit/form/Select/index.tsx
@@ -138,6 +138,10 @@ const Select: React.ComponentType<{
     return () => document.removeEventListener('mouseup', documentClickHandler);
   }, [isExpanded]);
 
+  useEffect(() => {
+    value === selectedValue || setSelectedValue(value);
+  }, [value]);
+
   const styledInputWrapper = (
     <StyledInputWrapper
       error={hasError}


### PR DESCRIPTION
**Description of changes**

When the Select component is implemented once in parallel state contexts, React seems unable to identify the parent container has changed the value passed into this component, creating a sticky internal state.

This easy commit simply adds an effect hook to ensure the state is updated if the value passed changes unexpectedly.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
