### PR TITLE
Fix workflowType data structure to prevent file page crash

### DIFF
--- a/components/pages/file-entity/DataAndAnalysis/index.tsx
+++ b/components/pages/file-entity/DataAndAnalysis/index.tsx
@@ -19,7 +19,11 @@
 
 import { FileCard, TableDiv } from '../common';
 import SimpleTable from 'uikit/Table/SimpleTable';
-import { DataAnalysisInfo } from '../types';
+import { DataAnalysisInfo, DataAnalysisWorkflowType } from '../types';
+
+function getWorkflowTypeDisplay(workflowType: DataAnalysisWorkflowType): string {
+  return workflowType ? [workflowType.workflow_name, workflowType.workflow_version].join(', ') : '';
+}
 
 export default ({ data }: { data: DataAnalysisInfo }) => {
   const tableData = {
@@ -27,7 +31,7 @@ export default ({ data }: { data: DataAnalysisInfo }) => {
     'Data Type': data.dataType,
     Platform: data.platform,
     'Genome Build': data.genomeBuild,
-    'Workflow Type': data.workflowType,
+    'Workflow Type': getWorkflowTypeDisplay(data.workflowType),
     Software: data.software,
   };
 

--- a/components/pages/file-entity/dummyData.tsx
+++ b/components/pages/file-entity/dummyData.tsx
@@ -42,7 +42,7 @@ export const dummyDataAnalysisInfo: DataAnalysisInfo = {
   dataType: 'Aligned Reads',
   platform: 'Illumina',
   genomeBuild: 'GRCh38',
-  workflowType: 'DNA seq alignment',
+  workflowType: { workflow_name: 'DNA seq alignment', workflow_version: '1.0.0' },
   software: 'BWA MEM',
 };
 

--- a/components/pages/file-entity/types.tsx
+++ b/components/pages/file-entity/types.tsx
@@ -34,12 +34,17 @@ export type FileSummaryInfo = {
   repoCountry: string;
 };
 
+export type DataAnalysisWorkflowType = {
+  workflow_name: string;
+  workflow_version: string;
+};
+
 export type DataAnalysisInfo = {
   experimentalStrategy: string;
   dataType: string;
   platform: string;
   genomeBuild: string;
-  workflowType: string;
+  workflowType?: DataAnalysisWorkflowType;
   software: string;
 };
 


### PR DESCRIPTION
**Description of changes**

File page was crashing for restricted files. The problem was attempting to render a table cell content from an object instead of string. The data structure of workflowType property was different (object instead of string) so by writing a snippet to convert this data into a presentable string everything loads and renders successfully.


**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [x] Connected ticket to PR
