### PR TITLE
add custom Footer prop to Modal

### DIFF
--- a/uikit/Modal/index.tsx
+++ b/uikit/Modal/index.tsx
@@ -30,6 +30,40 @@ import { UikitIconNames } from 'uikit/Icon/icons';
 import { BUTTON_SIZES, BUTTON_VARIANTS } from 'uikit/Button/constants';
 import { ButtonSize } from 'uikit/Button/types';
 
+const DefaultFooter = ({
+  actionVisible,
+  actionButtonId,
+  actionDisabled,
+  onActionClick,
+  actionButtonText,
+  buttonSize,
+  onCancelClick,
+  cancelText,
+}) => (
+  <ButtonContainer>
+    {actionVisible && (
+      <Button
+        id={actionButtonId}
+        size={buttonSize || BUTTON_SIZES.MD}
+        disabled={actionDisabled}
+        onClick={onActionClick}
+      >
+        {actionButtonText}
+      </Button>
+    )}
+    <Button
+      variant={BUTTON_VARIANTS.TEXT}
+      css={css`
+        margin-left: 10px;
+      `}
+      size={buttonSize || BUTTON_SIZES.MD}
+      onClick={onCancelClick}
+    >
+      {cancelText}
+    </Button>
+  </ButtonContainer>
+);
+
 export const ModalContainer = styled('div')`
   position: relative;
   border-radius: 20px;
@@ -94,6 +128,7 @@ const ModalComponent: React.ComponentType<{
   onCancelClick?: React.ComponentProps<typeof Button>['onClick'];
   onCloseClick?: React.ComponentProps<typeof FocusWrapper>['onClick'];
   ContainerEl?: React.ReactType;
+  FooterEl?: React.FC;
 }> = ({
   title = 'Add Users',
   titleIconConfig = {
@@ -111,8 +146,10 @@ const ModalComponent: React.ComponentType<{
   actionDisabled = false,
   children,
   ContainerEl,
+  FooterEl,
 }) => {
   const Container = ContainerEl ? ContainerEl : ModalContainer;
+  const Footer = FooterEl ? FooterEl : DefaultFooter;
 
   return (
     <Container>
@@ -175,28 +212,16 @@ const ModalComponent: React.ComponentType<{
         </div>
       </div>
       <ModalFooter>
-        <ButtonContainer>
-          {actionVisible && (
-            <Button
-              id={actionButtonId}
-              size={buttonSize || BUTTON_SIZES.MD}
-              disabled={actionDisabled}
-              onClick={onActionClick}
-            >
-              {actionButtonText}
-            </Button>
-          )}
-          <Button
-            variant={BUTTON_VARIANTS.TEXT}
-            css={css`
-              margin-left: 10px;
-            `}
-            size={buttonSize || BUTTON_SIZES.MD}
-            onClick={onCancelClick}
-          >
-            {cancelText}
-          </Button>
-        </ButtonContainer>
+        <Footer
+          actionVisible={actionVisible}
+          actionButtonId={actionButtonId}
+          actionDisabled={actionDisabled}
+          onActionClick={onActionClick}
+          actionButtonText={actionButtonText}
+          buttonSize={buttonSize}
+          onCancelClick={onCancelClick}
+          cancelText={cancelText}
+        />
       </ModalFooter>
     </Container>
   );

--- a/uikit/Modal/stories.tsx
+++ b/uikit/Modal/stories.tsx
@@ -83,6 +83,22 @@ const ModalStories = storiesOf(`${__dirname}`, module)
       </Modal.Overlay>
     );
   })
+  .add('Custom Footer', () => (
+    <Modal.Overlay>
+      <Modal
+        title="A small modal"
+        titleIconConfig={{
+          name: ICON_NAMES.warning,
+          fill: BUILT_IN_ICON_COLORS.warning,
+        }}
+        FooterEl={() => <footer>Custom Footer</footer>}
+      >
+        <div style={{ width: '300px' }}>
+          Setting a fixed width of the children will make the modal shrink down to fit
+        </div>
+      </Modal>
+    </Modal.Overlay>
+  ))
   .add('Small configuation', () => (
     <Modal.Overlay>
       <Modal


### PR DESCRIPTION
**Description of changes**

- allows passing of custom Footer element
- defaults to previous Footer with props for backwards compatibility

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [x] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
