### PR TITLE
🐛 Fix Overlap of Facet Option Text and Count (#1999)

### DIFF
--- a/uikit/OptionsList/index.tsx
+++ b/uikit/OptionsList/index.tsx
@@ -90,7 +90,7 @@ const OptionsList: React.ComponentType<{
           display: flex;
           align-items: center;
           justify-content: space-between;
-          height: 25px;
+          min-height: 25px;
           padding: 2px 12px;
           width: calc(100% - (2 * 12px));
           &:hover {
@@ -143,9 +143,8 @@ const OptionsList: React.ComponentType<{
               <div
                 ref={optionRef}
                 css={css`
-                  white-space: nowrap;
-                  overflow: hidden;
-                  text-overflow: ellipsis;
+                  word-break: break-word;
+                  line-height: normal;
                 `}
               >
                 {parseDisplayValue(option.key)}


### PR DESCRIPTION
## Description of changes

Addresses a styling bug ( #1999 ) where long text labels for facet options could extend beyond the visible area by allowing the text to span multiple lines.

**BEFORE:**
<img width="264" alt="125648213-93ed1d48-b6ee-4825-9836-b3315e874234" src="https://user-images.githubusercontent.com/3392776/130297561-7ed0ebb7-6b42-4440-b153-5b8f7a51c360.png">

**AFTER:**
![Screen Shot 2021-08-20 at 5 56 51 PM](https://user-images.githubusercontent.com/3392776/130297414-fea4420e-f538-4eba-804c-f789bd1330bb.png)

## Type of Change

- [x] Bug
- [ ] Styling
- [ ] New Feature

## Checklist before requesting review:

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [x] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
