### PR TITLE
Make filter overflow auto, not always scroll

### DIFF
--- a/uikit/DropdownPanel/index.tsx
+++ b/uikit/DropdownPanel/index.tsx
@@ -113,7 +113,7 @@ export const DropdownPanelList = styled('ul')`
   padding: 0;
   font-weight: normal;
   max-height: 80px;
-  overflow: scroll;
+  overflow: auto;
 `;
 
 export const DropdownPanelListItemLabel = styled('label')`


### PR DESCRIPTION
**Description of changes**

Scroll bars were always present on the filters. Now they are only there when needed.

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [] Connected ticket to PR
