### PR TITLE
🐛 Prevent Scrollbars on Dashboard Table Dropdown Filters (#2031)

### DIFF
--- a/.storybook/PropTypesTable/ReactTableContainer.tsx
+++ b/.storybook/PropTypesTable/ReactTableContainer.tsx
@@ -54,13 +54,13 @@ export default styled('div')`
   }
   .ReactTable.has-filters .rt-table {
     opacity: 1 !important;
-    min-height: 230px;
+    min-height: 250px;
     .rt-tbody .rt-tr-group {
       max-height: 28px;
     }
   }
   .ReactTable.has-filters.no-data .rt-table {
-    margin-bottom: -165px;
+    margin-bottom: -185px;
     border-bottom: none;
   }
   .ReactTable .rt-thead {

--- a/uikit/DropdownPanel/index.tsx
+++ b/uikit/DropdownPanel/index.tsx
@@ -112,7 +112,7 @@ export const DropdownPanelList = styled('ul')`
   margin: 0;
   padding: 0;
   font-weight: normal;
-  max-height: 80px;
+  max-height: 100px;
   overflow: auto;
 `;
 

--- a/uikit/Table/reactTableDefaultStyle.tsx
+++ b/uikit/Table/reactTableDefaultStyle.tsx
@@ -50,13 +50,13 @@ export default css`
   }
   &.ReactTable.has-filters .rt-table {
     opacity: 1 !important;
-    min-height: 230px;
+    min-height: 250px;
     .rt-tbody .rt-tr-group {
       max-height: 28px;
     }
   }
   &.ReactTable.has-filters.no-data .rt-table {
-    margin-bottom: -165px;
+    margin-bottom: -185px;
     border-bottom: none;
   }
   &.ReactTable .rt-thead {

--- a/uikit/Table/styledComponent.tsx
+++ b/uikit/Table/styledComponent.tsx
@@ -46,14 +46,14 @@ export const StyledTable = styled<typeof ReactTable, StyledTableProps>(ReactTabl
     &.has-filters {
       .rt-table {
         opacity: 1 !important;
-        min-height: 230px;
+        min-height: 250px;
         .rt-tbody .rt-tr-group {
           max-height: 28px;
         }
       }
       &.no-data {
         .rt-table {
-          margin-bottom: -165px;
+          margin-bottom: -185px;
           border-bottom: none;
         }
       }


### PR DESCRIPTION
**Description of changes**

Increase the `max-height` of the `DropdownPanel` component to prevent scroll bars from showing up when there are up to 4 items in the list (4 was chosen as it is the max number of options for the table header filters for the foreseeable future)

**Type of Change**

- [x] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [x] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
