### PR TITLE
Hotfix 1.101.3 - Embargo Stage Facet Ordering

### DIFF
--- a/components/pages/file-repository/FacetPanel/index.tsx
+++ b/components/pages/file-repository/FacetPanel/index.tsx
@@ -292,10 +292,12 @@ const FacetPanel = () => {
     }));
 
     // Control ordering of options for specific facets
-    switch (facet.name) {
+    switch (facet.facetPath) {
       case 'embargo_stage':
         const order = ['PROGRAM_ONLY', 'MEMBER_ACCESS', 'ASSOCIATE_ACCESS', 'PUBLIC'];
-        return order.map((order) => options.find((option) => option.key === order)).filter(Boolean);
+        return order
+          .map((embargoStage) => options.find((option) => option.key === embargoStage))
+          .filter(Boolean);
       default:
         return options;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argo-platform-ui",
-  "version": "1.101.2",
+  "version": "1.101.3",
   "scripts": {
     "dev": "next -p 8080",
     "build": "rm -rf .next && next build",


### PR DESCRIPTION
**Description of changes**

Ensure that the embargo stage facets are displayed in order of least->most permissive. Very minor fix, just changing which variable is being checked against to identify the correct facet to re-order.


**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [ ] ~~Connected ticket to PR~~
