### PR TITLE
update disabled colors in uikit

### DIFF
--- a/uikit/form/MultiSelect/index.tsx
+++ b/uikit/form/MultiSelect/index.tsx
@@ -134,6 +134,7 @@ const SelectedItem: any = styled(Tag)`
   margin-bottom: 2px;
 
   &.disabled {
+    color: ${({ theme }) => theme.colors.grey};
     background-color: ${({ theme }) => theme.colors.grey_2};
   }
 `;
@@ -443,7 +444,7 @@ const MultiSelect = ({
               className={clsx({ disabled: isDisabled, hasError, focused: focusState })}
             >
               {item.displayName}&nbsp;&nbsp;
-              <Icon width="8px" height="8px" name="times" fill="#fff" />
+              <Icon width="8px" height="8px" name="times" fill={isDisabled ? theme.colors.grey : theme.colors.white} />
             </SelectedItem>
           ))}
         <Input

--- a/uikit/form/Select/styledComponents.tsx
+++ b/uikit/form/Select/styledComponents.tsx
@@ -29,7 +29,7 @@ export const POPUP_POSITIONS = { UP: 'UP' as PopupPosition, DOWN: 'DOWN' as Popu
 
 export const DropdownIcon = withProps(({ disabled, theme }) => ({
   name: 'chevron_down',
-  fill: disabled ? theme.input.textColors.disabled : 'black',
+  fill: disabled ? theme.colors.grey_disabled : 'black',
 }))(styled<typeof Icon, { disabled?: boolean }>(Icon)`
   height: 100%;
   width: 10px;

--- a/uikit/form/Textarea/index.tsx
+++ b/uikit/form/Textarea/index.tsx
@@ -166,7 +166,12 @@ const Textarea = ({
           }
 
           &.disabled {
+            border-color: ${theme.input.borderColors.disabled};
             background-color: ${theme.input.colors.disabled};
+            color: ${theme.input.colors.grey};
+            &:hover {
+              border-color: #d0d1d8 !important;
+            }
           }
         `}
         disabled={isDisabled}

--- a/uikit/form/common.tsx
+++ b/uikit/form/common.tsx
@@ -75,10 +75,10 @@ export const StyledInputWrapper = styled<'div', StyledInputWrapperProps>('div')`
 
   &:hover {
     border-color: ${({ theme, disabled, error }) => {
-      if (error) return theme.colors.error;
-      else if (disabled) return 'initial';
-      else return theme.colors.secondary_1;
-    }};
+    if (error) return theme.colors.error;
+    else if (disabled) return theme.colors.grey_disabled;
+    else return theme.colors.secondary_1;
+  }};
   }
 
   ${({ inputState, theme }) =>

--- a/uikit/theme/defaultTheme/input.tsx
+++ b/uikit/theme/defaultTheme/input.tsx
@@ -39,8 +39,8 @@ export default {
     [INPUT_STATES.default]: colors.black,
     [INPUT_STATES.active]: colors.black,
     [INPUT_STATES.focus]: colors.black,
-    [INPUT_STATES.disabled]: '#d0d1d8',
-    [INPUT_STATES.error]: '#d0d1d8',
+    [INPUT_STATES.disabled]: colors.grey,
+    [INPUT_STATES.error]: colors.grey,
   },
   borderColors: {
     [INPUT_STATES.default]: colors.grey_1,

--- a/uikit/theme/defaultTheme/multiSelect.tsx
+++ b/uikit/theme/defaultTheme/multiSelect.tsx
@@ -26,6 +26,6 @@ export default {
   },
   listBorderColor: colors.grey_1,
   placeHolderColor: colors.grey,
-  disabledTextColor: '#d0d1d8',
+  disabledTextColor: colors.grey,
   disabledBackgroundColor: '#f6f6f7',
 };

--- a/uikit/theme/defaultTheme/radiocheckbox.tsx
+++ b/uikit/theme/defaultTheme/radiocheckbox.tsx
@@ -25,7 +25,7 @@ export default {
   },
   textColors: {
     default: colors.black,
-    disabled: '#d0d1d8',
+    disabled: colors.grey,
   },
   backgroundColors: {
     default: colors.white,


### PR DESCRIPTION
re: https://github.com/icgc-argo/dac-ui/issues/179

tested with storybook & setting fields on "create program" page to disabled

- make text inputs, checkboxes, radio buttons, select, and multiselect have grey text when disabled
- change textarea borders in disabled state

i refrained from reorganizing the colors, but i added a note in our uikit wiki page about organizing colors better.