### PR TITLE
✨ Add 'Clear Filters' Button to Dashboard Table Header (#2035)

### DIFF
--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
@@ -31,7 +31,12 @@ import Table, { TableColumnConfig } from 'uikit/Table';
 
 import { displayDate } from 'global/utils/common';
 import Icon from 'uikit/Icon';
-import DropdownPanel, { FilterOption, ListFilter, TextInputFilter } from 'uikit/DropdownPanel';
+import DropdownPanel, {
+  FilterOption,
+  ListFilter,
+  TextInputFilter,
+  FilterClearButton,
+} from 'uikit/DropdownPanel';
 import {
   DataTableStarIcon as StarIcon,
   TableInfoHeaderContainer,
@@ -84,7 +89,9 @@ export default ({
   const [filterState, setFilterState] = React.useState([]);
   const updateFilter = (field: ProgramDonorSummaryEntryField, value: string | string[]) => {
     const newFilters = filterState.filter((x) => x.field !== field);
-    newFilters.push({ field: field, values: typeof value === 'string' ? [value] : value });
+    if (value.length) {
+      newFilters.push({ field: field, values: typeof value === 'string' ? [value] : value });
+    }
     setFilterState(newFilters);
   };
   const clearFilter = (field: ProgramDonorSummaryEntryField) => {
@@ -664,11 +671,27 @@ export default ({
       ],
     },
     {
-      Header: 'Last Updated',
-      accessor: 'updatedAt',
-      Cell: ({ original }: { original: DonorSummaryRecord }) => {
-        return <div>{displayDate(original.updatedAt)}</div>;
-      },
+      Header: filterState.length ? (
+        <FilterClearButton
+          size="sm"
+          variant="text"
+          type="button"
+          onClick={() => setFilterState([])}
+        >
+          Clear Filters
+        </FilterClearButton>
+      ) : (
+        <></>
+      ),
+      columns: [
+        {
+          Header: 'Last Updated',
+          accessor: 'updatedAt',
+          Cell: ({ original }: { original: DonorSummaryRecord }) => {
+            return <div>{displayDate(original.updatedAt)}</div>;
+          },
+        },
+      ],
     },
   ];
 

--- a/uikit/DropdownPanel/index.tsx
+++ b/uikit/DropdownPanel/index.tsx
@@ -132,6 +132,13 @@ export const DropdownPanelButtonSection = styled('div')`
   justify-content: space-between;
 `;
 
+export const FilterClearButton = styled(DropdownPanelTextButton)`
+  font-size: 11px;
+  font-weight: bold;
+  line-height: 1.45;
+  margin-left: auto;
+`;
+
 export const FilterWrapper = ({
   panelLegend = 'Filter',
   cancelLabel = 'Cancel',


### PR DESCRIPTION
**Description of changes**

* Adds a 'Clear Filters' button to the dashboard table to facilitate clearing any/all filters at once

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
