### PR TITLE
revert changes from uikit 1.14.1

### DIFF
--- a/uikit/form/MultiSelect/index.tsx
+++ b/uikit/form/MultiSelect/index.tsx
@@ -335,9 +335,7 @@ const MultiSelect = ({
   };
 
   const handleInputChange = (event) => {
-    const newValue = event.target.value;
-    setSearchString(newValue);
-    single && onChange(createCustomEvent(event, [newValue]), null);
+    setSearchString(event.target.value);
   };
 
   const handleInputKeyDown = (event) => {
@@ -452,7 +450,6 @@ const MultiSelect = ({
           autoComplete="off"
           disabled={isDisabled}
           id={id || `${name}-multiselect`}
-          name={id || `${name}-multiselect`}
           single={single}
           onBlur={handleInputBlur}
           onChange={handleInputChange}


### PR DESCRIPTION
remove the change event and `name` attribute (which would cause a change event to fire on autocomplete)

those changes had no effect on platform, and the wrong effect on DACO, so rolling back for now.

previous PR: https://github.com/icgc-argo/platform-ui/pull/2053/