### PR TITLE
⚡️ use bucket_count aggregation instead of counting buckets

### DIFF
--- a/components/pages/file-repository/StatsCard/STATS_BAR.gql
+++ b/components/pages/file-repository/StatsCard/STATS_BAR.gql
@@ -5,14 +5,10 @@ query STATS($filters: JSON) {
     }
     aggregations(filters: $filters, include_missing: true, aggregations_filter_themselves: true) {
       donors__donor_id {
-        buckets {
-          key
-        }
+        bucket_count
       }
       study_id {
-        buckets {
-          key
-        }
+        bucket_count
       }
       file__size {
         stats {

--- a/components/pages/file-repository/StatsCard/index.tsx
+++ b/components/pages/file-repository/StatsCard/index.tsx
@@ -32,9 +32,7 @@ type StatsBarQueryInput = {
 };
 
 type BucketAggregationData = {
-  buckets: {
-    key: string;
-  }[];
+  bucket_count: number;
 };
 type SumAggregationData = {
   stats: {
@@ -65,9 +63,9 @@ export const useFileRepoStatsBarQuery = (filters?: FileRepoFiltersType) => {
 
   const stats = {
     filesCount: hook?.data ? hook.data.file.hits.total : 0,
-    donorsCount: hook?.data ? hook.data.file.aggregations.donors__donor_id.buckets.length : 0,
+    donorsCount: hook?.data ? hook.data.file.aggregations.donors__donor_id.bucket_count : 0,
     primarySites: 0,
-    programsCount: hook?.data ? hook.data.file.aggregations.study_id.buckets.length : 0,
+    programsCount: hook?.data ? hook.data.file.aggregations.study_id.bucket_count : 0,
     totalFileSize: hook?.data ? hook.data.file.aggregations.file__size.stats.sum : 0,
   };
 


### PR DESCRIPTION
**Description of changes**

Paying rent for staying at @joneubank 

Change the stats aggregation to use `bucket_count` rather than counting buckets to reduce amount of data transported. 
Tested to confirm working.

**Type of Change**

- [ ] Bug
- [x] New Feature
- [ ] Styling

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
