### PR TITLE
🐛  #1794 Handle Users with no Access

### DIFF
--- a/components/pages/user/ApiTokenBox/index.tsx
+++ b/components/pages/user/ApiTokenBox/index.tsx
@@ -79,7 +79,7 @@ const ApiTokenBox = ({
 
   const getTagValue = () => (apiToken || generatedApiToken ? getDayValue(exp) : '');
 
-  const isExpired = exp <= 0 && (apiToken || generatedApiToken);
+  const isExpired = (apiToken || generatedApiToken) && exp !== null && exp <= 0;
   const disableCopy = loading || isExpired || isGeneratingApiToken || !key;
   const disableGenerate = loading || isGeneratingApiToken || !isDacoApproved;
 

--- a/components/pages/user/ApiTokenBox/index.tsx
+++ b/components/pages/user/ApiTokenBox/index.tsx
@@ -36,10 +36,12 @@ const ApiTokenBox = ({
   apiToken,
   loading,
   isDacoApproved,
+  hasProgramAccess,
 }: {
   apiToken: ApiToken;
   loading: boolean;
   isDacoApproved: boolean;
+  hasProgramAccess: boolean;
 }) => {
   const [generatedApiToken, setGeneratedApiToken] = React.useState(null);
   const [isGeneratingApiToken, setIsGeneratingApiToken] = React.useState(false);
@@ -162,7 +164,7 @@ const ApiTokenBox = ({
           size={BANNER_SIZE.SM}
           variant={BANNER_VARIANTS.WARNING}
           content={
-            isDacoApproved ? (
+            isDacoApproved && hasProgramAccess ? (
               <>
                 <span>
                   &#8226; Your API token is associated with your user credentials and should{' '}

--- a/components/pages/user/ApiTokenBox/index.tsx
+++ b/components/pages/user/ApiTokenBox/index.tsx
@@ -83,7 +83,7 @@ const ApiTokenBox = ({
 
   const isExpired = (apiToken || generatedApiToken) && exp !== null && exp <= 0;
   const disableCopy = loading || isExpired || isGeneratingApiToken || !key;
-  const disableGenerate = loading || isGeneratingApiToken || !isDacoApproved;
+  const disableGenerate = loading || isGeneratingApiToken || !isDacoApproved || !hasProgramAccess;
 
   return (
     <Box title="API Token" iconName="key">

--- a/components/pages/user/index.tsx
+++ b/components/pages/user/index.tsx
@@ -46,6 +46,7 @@ export function UserPage() {
   const isDacoApproved = get(data, ['self', 'isDacoApproved']);
   const apiToken = get(data, ['self', 'apiKey']);
   const programs = get(data, 'programs');
+  const hasProgramAccess = programs && programs.length > 0;
 
   return (
     <DefaultLayout>
@@ -67,7 +68,12 @@ export function UserPage() {
         </Row>
         <Row nogutter>
           <Column sm={12} md={6}>
-            <ApiTokenBox apiToken={apiToken} loading={loading} isDacoApproved={isDacoApproved} />
+            <ApiTokenBox
+              apiToken={apiToken}
+              loading={loading}
+              isDacoApproved={isDacoApproved}
+              hasProgramAccess={hasProgramAccess}
+            />
           </Column>
           <Column sm={12} md={6}>
             <ProgramAccessBox

--- a/pages/user/index.tsx
+++ b/pages/user/index.tsx
@@ -25,7 +25,7 @@ import { decodeToken } from 'global/utils/egoJwt';
 import { UserPage } from 'components/pages/user';
 
 export default createPage({
-  getInitialProps: async context => {
+  getInitialProps: async (context) => {
     const { egoJwt, asPath, query, res } = context;
     const data = decodeToken(egoJwt);
     const firstName = get(data, 'context.user.firstName', '');


### PR DESCRIPTION
**Description of changes**

Disables use of Generate API Token button for users w/o DACO Access or Program Membership
Updates copy for above scenario
Updates 'Expired' tag logic to only render when user's api token is expired, not in other scenarios

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
