### PR TITLE
alias emotion core so dependencies, eg uikit, use platform-ui version

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -44,6 +44,13 @@ module.exports = withImages({
       // This asn1 nonsense is to allow the jsonwebtokens dependency `parse-asn1` to get webpacked correctly. It has a dependency called `asn1.js` and a file with the same name that webpack gets confused.
       'asn1.js': urlJoin(__dirname, '/node_modules/asn1.js/lib/asn1.js'),
     };
+    // ensure UIKit (local dev) uses platform-ui emotion, this is needed to properly resolve `theme` from ThemeProvider
+    config.resolve.alias['@emotion/core'] = path.resolve(
+      __dirname,
+      '.',
+      'node_modules',
+      '@emotion/core',
+    );
     config.module.rules = [
       ...config.module.rules,
       {


### PR DESCRIPTION
**Description of changes**

alias emotion core so dependencies, eg uikit, use platform-ui version
important for local dev with uikit
normally npm i would resolve dependencies correctly ie. peerDep

**Type of Change**

- [ ] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
