### PR TITLE
🐛 Return `null` for Blank Workflow Type Fields

### DIFF
--- a/components/pages/file-entity/DataAndAnalysis/index.tsx
+++ b/components/pages/file-entity/DataAndAnalysis/index.tsx
@@ -30,7 +30,7 @@ function getWorkflowTypeDisplay(workflowType: DataAnalysisWorkflowType): string 
 }
 
 const getWorkflowNameLink = (workflowType: DataAnalysisWorkflowType) => {
-  if (!workflowType || !workflowType.workflow_name) return '';
+  if (!workflowType || !workflowType.workflow_name) return null;
 
   switch (workflowType.workflow_name) {
     case WORKFLOW_NAMES.dnaSeq:
@@ -69,7 +69,7 @@ const getWorkflowNameLink = (workflowType: DataAnalysisWorkflowType) => {
 };
 
 const getWorkflowVersionLink = (workflowType: DataAnalysisWorkflowType) => {
-  if (!workflowType || !workflowType.workflow_name) return '';
+  if (!workflowType || !workflowType.workflow_name) return null;
 
   switch (workflowType.workflow_name) {
     case WORKFLOW_NAMES.dnaSeq:


### PR DESCRIPTION
**Description of changes**

* Return `null` instead of an empty string `''` when there is no `workflowType` for a file on the File Entity page

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
