### PR TITLE
🐛 #2197 Wrap long Donor ID values

### DIFF
--- a/uikit/Table/SimpleTable/index.tsx
+++ b/uikit/Table/SimpleTable/index.tsx
@@ -40,8 +40,12 @@ const SimpleTable = ({ data }) => {
         withOutsideBorder
         data={tableData}
         columns={[
-          { sortable: false, accessor: 'key', style: { whiteSpace: 'unset' } },
-          { accessor: 'val', style: { whiteSpace: 'unset' } },
+          {
+            sortable: false,
+            accessor: 'key',
+            style: { whiteSpace: 'unset', wordBreak: 'break-word' },
+          },
+          { accessor: 'val', style: { whiteSpace: 'unset', wordBreak: 'break-word' } },
         ]}
       />
     </div>


### PR DESCRIPTION
**Description of changes**

Adds word-break property to Simple Table component to break up lengthy donor IDs and other values

https://app.zenhub.com/workspaces/icgc-argo-platform-dk-production-board-5e542d38415f5034e9fed89d/issues/icgc-argo/platform-ui/2197

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
