### PR TITLE
🚩 Enable `Sequencing Reads Properties` Section of File Entity Page (#2219)

### DIFF
--- a/components/pages/file-entity/FILE_ENTITY_QUERY.gql
+++ b/components/pages/file-entity/FILE_ENTITY_QUERY.gql
@@ -32,6 +32,20 @@ query FILE_ENTITY_QUERY($filters: JSON) {
           study_id
           analysis_tools
           embargo_stage
+          metrics {
+            average_insert_size
+            average_length
+            duplicated_bases
+            error_rate
+            mapped_bases_cigar
+            mapped_reads
+            mismatch_bases
+            paired_reads
+            pairs_on_different_chromosomes
+            properly_paired_reads
+            total_bases
+            total_reads
+          }
 
           file {
             size

--- a/components/pages/file-entity/FileCardsLayout.tsx
+++ b/components/pages/file-entity/FileCardsLayout.tsx
@@ -56,14 +56,13 @@ const FileCardsLayout: React.ComponentType<{
           <AssociatedDonors donors={fileData.donorRecords} />
         </PaddedColumn>
       </PaddedRow>
-      {/* TODO: un-comment once `metrics` object is available in API */}
-      {/* {fileData.dataAnalysis.dataType === 'aligned_reads' && (
+      {fileData.dataAnalysis.dataType === 'Aligned Reads' && fileData.metrics && (
         <PaddedRow>
           <PaddedColumn>
-            <SequencingReadProperties />
+            <SequencingReadProperties metrics={fileData.metrics} />
           </PaddedColumn>
         </PaddedRow>
-      )} */}
+      )}
     </div>
   );
 };

--- a/components/pages/file-entity/SequencingReadProperties/index.tsx
+++ b/components/pages/file-entity/SequencingReadProperties/index.tsx
@@ -25,7 +25,7 @@ import Typography from 'uikit/Typography';
 import { useTheme } from 'uikit/ThemeProvider';
 import { FileCard, TableDiv } from '../common';
 
-const SequencingReadProperties = () => {
+const SequencingReadProperties = ({ metrics }: { metrics: any }) => {
   const theme = useTheme();
 
   const CenteredCol = styled(Col)`
@@ -61,24 +61,23 @@ const SequencingReadProperties = () => {
               `}
             >
               <CenteredCol lg={2} md={12}>
-                {/* TODO: un-comment and use values from metrics object once available in API */}
-                <StatNumber>{/* {total_reads.toLocaleString()} */}</StatNumber>
+                <StatNumber>{metrics.totalReads.toLocaleString()}</StatNumber>
                 <StatLabel>Total Reads</StatLabel>
               </CenteredCol>
               <CenteredCol lg={2} md={12}>
-                <StatNumber>{/* {paired_reads.toLocaleString()} */}</StatNumber>
+                <StatNumber>{metrics.pairedReads.toLocaleString()}</StatNumber>
                 <StatLabel>Paired Reads</StatLabel>
               </CenteredCol>
               <CenteredCol lg={4} md={12}>
-                <StatNumber>{/* {pairs_on_different_chromosomes.toLocaleString()} */}</StatNumber>
+                <StatNumber>{metrics.pairsOnDifferentChromosomes.toLocaleString()}</StatNumber>
                 <StatLabel>Pairs on Different Chromosomes</StatLabel>
               </CenteredCol>
               <CenteredCol lg={2} md={12}>
-                <StatNumber>{/* {average_insert_size.toLocaleString()} */}</StatNumber>
+                <StatNumber>{metrics.averageInsertSize.toLocaleString()}</StatNumber>
                 <StatLabel>Average Insert Size</StatLabel>
               </CenteredCol>
               <CenteredCol lg={2} md={12}>
-                <StatNumber>{/* {average_length.toLocaleString()} */}</StatNumber>
+                <StatNumber>{metrics.averageLength.toLocaleString()}</StatNumber>
                 <StatLabel>Average Length</StatLabel>
               </CenteredCol>
             </Row>

--- a/components/pages/file-entity/SequencingReadProperties/index.tsx
+++ b/components/pages/file-entity/SequencingReadProperties/index.tsx
@@ -24,8 +24,9 @@ import { Col, Row } from 'react-grid-system';
 import Typography from 'uikit/Typography';
 import { useTheme } from 'uikit/ThemeProvider';
 import { FileCard, TableDiv } from '../common';
+import { FileMetricsInfo } from '../types';
 
-const SequencingReadProperties = ({ metrics }: { metrics: any }) => {
+const SequencingReadProperties = ({ metrics }: { metrics: FileMetricsInfo }) => {
   const theme = useTheme();
 
   const CenteredCol = styled(Col)`

--- a/components/pages/file-entity/dummyData.tsx
+++ b/components/pages/file-entity/dummyData.tsx
@@ -23,6 +23,7 @@ import {
   DataAnalysisInfo,
   DonorRecord,
   FileRecord,
+  FileMetricsInfo
 } from './types';
 
 export const dummyFileSummaryInfo: FileSummaryInfo = {
@@ -99,7 +100,7 @@ export const dummyFileRecords: Array<FileRecord> = [
   },
 ];
 
-export const dummyMetricsData: any = {
+export const dummyMetricsInfo: FileMetricsInfo = {
   averageInsertSize: 162.1,
   averageLength: 76,
   duplicatedBases: 456,

--- a/components/pages/file-entity/dummyData.tsx
+++ b/components/pages/file-entity/dummyData.tsx
@@ -98,3 +98,18 @@ export const dummyFileRecords: Array<FileRecord> = [
     actions: FileAccessState.CONTROLLED,
   },
 ];
+
+export const dummyMetricsData: any = {
+  averageInsertSize: 162.1,
+  averageLength: 76,
+  duplicatedBases: 456,
+  errorRate: 0.004498106,
+  mappedBasesCigar: 12672,
+  mappedReads: 168,
+  mismatchBases: 57,
+  pairsOnDifferentChromosomes: 0,
+  pairedReads: 170,
+  properlyPairedReads: 168,
+  totalBases: 12920,
+  totalReads: 170,
+};

--- a/components/pages/file-entity/index.stories.tsx
+++ b/components/pages/file-entity/index.stories.tsx
@@ -25,6 +25,7 @@ import {
   dummyDataAnalysisInfo,
   dummyFileRecords,
   dummyFileSummaryInfo,
+  dummyMetricsData,
 } from './dummyData';
 import clsx from 'clsx';
 import Head from '../head';
@@ -42,6 +43,7 @@ const FileRepositoryTableStories = storiesOf(`${__dirname}`, module).add('Basic'
     dataAnalysis: dummyDataAnalysisInfo,
     donorRecords: dummyAssociatedDonorsInfo,
     fileRecords: dummyFileRecords,
+    metrics: dummyMetricsData,
   };
 
   return (

--- a/components/pages/file-entity/index.stories.tsx
+++ b/components/pages/file-entity/index.stories.tsx
@@ -25,7 +25,7 @@ import {
   dummyDataAnalysisInfo,
   dummyFileRecords,
   dummyFileSummaryInfo,
-  dummyMetricsData,
+  dummyMetricsInfo,
 } from './dummyData';
 import clsx from 'clsx';
 import Head from '../head';
@@ -43,7 +43,7 @@ const FileRepositoryTableStories = storiesOf(`${__dirname}`, module).add('Basic'
     dataAnalysis: dummyDataAnalysisInfo,
     donorRecords: dummyAssociatedDonorsInfo,
     fileRecords: dummyFileRecords,
-    metrics: dummyMetricsData,
+    metrics: dummyMetricsInfo,
   };
 
   return (

--- a/components/pages/file-entity/types.tsx
+++ b/components/pages/file-entity/types.tsx
@@ -76,9 +76,24 @@ export type FileRecord = {
   actions: string;
 };
 
+export type FileMetricsInfo = {
+  averageInsertSize: number;
+  averageLength: number;
+  duplicatedBases: number;
+  errorRate: number;
+  mappedBasesCigar: number;
+  mappedReads: number;
+  mismatchBases: number;
+  pairedReads: number;
+  pairsOnDifferentChromosomes: number;
+  properlyPairedReads: number;
+  totalBases: number;
+  totalReads: number;
+};
+
 export type FileEntityData = {
   summary: FileSummaryInfo;
   dataAnalysis: DataAnalysisInfo;
   donorRecords: Array<DonorRecord>;
-  metrics: any;
+  metrics?: FileMetricsInfo;
 };

--- a/components/pages/file-entity/types.tsx
+++ b/components/pages/file-entity/types.tsx
@@ -80,4 +80,5 @@ export type FileEntityData = {
   summary: FileSummaryInfo;
   dataAnalysis: DataAnalysisInfo;
   donorRecords: Array<DonorRecord>;
+  metrics: any;
 };

--- a/components/pages/file-entity/useEntityData.tsx
+++ b/components/pages/file-entity/useEntityData.tsx
@@ -113,10 +113,28 @@ const useEntityData = ({ fileId }: { fileId: string }): EntityData => {
       };
     });
 
+    const metrics = entity.metrics ? (
+      {
+        averageInsertSize: entity.metrics.average_insert_size,
+        averageLength: entity.metrics.average_length,
+        duplicatedBases: entity.metrics.duplicated_bases,
+        errorRate: entity.metrics.error_rate,
+        mappedBasesCigar: entity.metrics.mapped_bases_cigar,
+        mappedReads: entity.metrics.mapped_reads,
+        mismatchBases: entity.metrics.mismatch_bases,
+        pairedReads: entity.metrics.paired_reads,
+        pairsOnDifferentChromosomes: entity.metrics.pairs_on_different_chromosomes,
+        properlyPairedReads: entity.metrics.properly_paired_reads,
+        totalBases: entity.metrics.total_bases,
+        totalReads: entity.metrics.total_reads,
+      }
+    ) : null;
+
     const entityData: FileEntityData = {
       summary,
       dataAnalysis,
       donorRecords,
+      metrics,
     };
 
     return { programShortName, access, size, embargoStage, data: entityData, loading };


### PR DESCRIPTION
**Description of changes**

* Adds `metrics` object to the `FILE_ENTITY_QUERY.gql`
* Renders the `Sequencing Reads Properties` section of the File Entity page for `Aligned Reads` files
* Adds a type for the `metrics` data

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
