### PR TITLE
🐛 Make `metrics` handling more generic, and add checks for `null`

### DIFF
--- a/components/pages/file-entity/FileCardsLayout.tsx
+++ b/components/pages/file-entity/FileCardsLayout.tsx
@@ -34,6 +34,14 @@ const PaddedColumn = styled(Col)`
   padding-bottom: 8px;
 `;
 
+const shouldShowSequencingReadProperties = (fileData: FileEntityData) => {
+  return (
+    fileData.dataAnalysis.dataType === 'Aligned Reads'
+      && fileData.dataAnalysis.workflowType?.workflow_name === 'DNA Seq Alignment'
+      && fileData.metrics
+  );
+};
+
 const FileCardsLayout: React.ComponentType<{
   fileData: FileEntityData;
 }> = ({ fileData }) => {
@@ -56,7 +64,7 @@ const FileCardsLayout: React.ComponentType<{
           <AssociatedDonors donors={fileData.donorRecords} />
         </PaddedColumn>
       </PaddedRow>
-      {fileData.dataAnalysis.dataType === 'Aligned Reads' && fileData.metrics && (
+      {shouldShowSequencingReadProperties(fileData) && (
         <PaddedRow>
           <PaddedColumn>
             <SequencingReadProperties metrics={fileData.metrics} />

--- a/components/pages/file-entity/SequencingReadProperties/index.tsx
+++ b/components/pages/file-entity/SequencingReadProperties/index.tsx
@@ -62,23 +62,23 @@ const SequencingReadProperties = ({ metrics }: { metrics: FileMetricsInfo }) => 
               `}
             >
               <CenteredCol lg={2} md={12}>
-                <StatNumber>{metrics.totalReads.toLocaleString()}</StatNumber>
+                <StatNumber>{metrics?.totalReads?.toLocaleString()}</StatNumber>
                 <StatLabel>Total Reads</StatLabel>
               </CenteredCol>
               <CenteredCol lg={2} md={12}>
-                <StatNumber>{metrics.pairedReads.toLocaleString()}</StatNumber>
+                <StatNumber>{metrics?.pairedReads?.toLocaleString()}</StatNumber>
                 <StatLabel>Paired Reads</StatLabel>
               </CenteredCol>
               <CenteredCol lg={4} md={12}>
-                <StatNumber>{metrics.pairsOnDifferentChromosomes.toLocaleString()}</StatNumber>
+                <StatNumber>{metrics?.pairsOnDifferentChromosomes?.toLocaleString()}</StatNumber>
                 <StatLabel>Pairs on Different Chromosomes</StatLabel>
               </CenteredCol>
               <CenteredCol lg={2} md={12}>
-                <StatNumber>{metrics.averageInsertSize.toLocaleString()}</StatNumber>
+                <StatNumber>{metrics?.averageInsertSize?.toLocaleString()}</StatNumber>
                 <StatLabel>Average Insert Size</StatLabel>
               </CenteredCol>
               <CenteredCol lg={2} md={12}>
-                <StatNumber>{metrics.averageLength.toLocaleString()}</StatNumber>
+                <StatNumber>{metrics?.averageLength?.toLocaleString()}</StatNumber>
                 <StatLabel>Average Length</StatLabel>
               </CenteredCol>
             </Row>

--- a/components/pages/file-entity/types.tsx
+++ b/components/pages/file-entity/types.tsx
@@ -77,18 +77,18 @@ export type FileRecord = {
 };
 
 export type FileMetricsInfo = {
-  averageInsertSize: number;
-  averageLength: number;
-  duplicatedBases: number;
-  errorRate: number;
-  mappedBasesCigar: number;
-  mappedReads: number;
-  mismatchBases: number;
-  pairedReads: number;
-  pairsOnDifferentChromosomes: number;
-  properlyPairedReads: number;
-  totalBases: number;
-  totalReads: number;
+  averageInsertSize?: number;
+  averageLength?: number;
+  duplicatedBases?: number;
+  errorRate?: number;
+  mappedBasesCigar?: number;
+  mappedReads?: number;
+  mismatchBases?: number;
+  pairedReads?: number;
+  pairsOnDifferentChromosomes?: number;
+  properlyPairedReads?: number;
+  totalBases?: number;
+  totalReads?: number;
 };
 
 export type FileEntityData = {

--- a/components/pages/file-entity/useEntityData.tsx
+++ b/components/pages/file-entity/useEntityData.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useQuery } from '@apollo/react-hooks';
-import { get } from 'lodash';
+import { get, mapKeys, camelCase } from 'lodash';
 import {
   FileSummaryInfo,
   FileAccessState,
@@ -40,6 +40,14 @@ type EntityData = {
 };
 
 const noData = { programShortName: null, access: null, size: null, data: null, embargoStage: null };
+
+const isValidMetricsObject = (metrics: any) => {
+  return (
+    typeof metrics === 'object'
+      && Object.values(metrics).length
+      && Object.values(metrics).every(v => v !== null)
+  );
+};
 
 const useEntityData = ({ fileId }: { fileId: string }): EntityData => {
   const filters = sqonBuilder.has(FileCentricDocumentField.file_id, fileId).build();
@@ -113,21 +121,8 @@ const useEntityData = ({ fileId }: { fileId: string }): EntityData => {
       };
     });
 
-    const metrics = entity.metrics ? (
-      {
-        averageInsertSize: entity.metrics.average_insert_size,
-        averageLength: entity.metrics.average_length,
-        duplicatedBases: entity.metrics.duplicated_bases,
-        errorRate: entity.metrics.error_rate,
-        mappedBasesCigar: entity.metrics.mapped_bases_cigar,
-        mappedReads: entity.metrics.mapped_reads,
-        mismatchBases: entity.metrics.mismatch_bases,
-        pairedReads: entity.metrics.paired_reads,
-        pairsOnDifferentChromosomes: entity.metrics.pairs_on_different_chromosomes,
-        properlyPairedReads: entity.metrics.properly_paired_reads,
-        totalBases: entity.metrics.total_bases,
-        totalReads: entity.metrics.total_reads,
-      }
+    const metrics = isValidMetricsObject(entity.metrics) ? (
+      mapKeys(entity.metrics, (_, key) => camelCase(key))
     ) : null;
 
     const entityData: FileEntityData = {


### PR DESCRIPTION
**Description of changes**

* Fixes a crash that would occur when the received `metrics` object would not match the schema
* Adds `null` checks, makes the object generation more generic for future expandability

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
