### PR TITLE
🐛 Fix crash when `metrics` is `null`

### DIFF
--- a/components/pages/file-entity/useEntityData.tsx
+++ b/components/pages/file-entity/useEntityData.tsx
@@ -18,7 +18,12 @@
  */
 
 import { useQuery } from '@apollo/react-hooks';
-import { get, mapKeys, camelCase } from 'lodash';
+import {
+  camelCase,
+  get,
+  isObject,
+  mapKeys,
+} from 'lodash';
 import {
   FileSummaryInfo,
   FileAccessState,
@@ -43,7 +48,7 @@ const noData = { programShortName: null, access: null, size: null, data: null, e
 
 const isValidMetricsObject = (metrics: any) => {
   return (
-    typeof metrics === 'object'
+    isObject(metrics)
       && Object.values(metrics).length
       && Object.values(metrics).every(v => v !== null)
   );


### PR DESCRIPTION
**Description of changes**

* Use lodash `isObject` to check type instead of relying on `typeof`, preventing a crash where the UI would try to do an `Object.values()` call on a null metrics object

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
