### PR TITLE
🐛 #2241 Prevent Loading on Selected File # Click

### DIFF
--- a/components/pages/file-repository/FileTable/TsvDownloadButton.tsx
+++ b/components/pages/file-repository/FileTable/TsvDownloadButton.tsx
@@ -147,6 +147,7 @@ const TsvDownloadButton = ({
         break;
       default:
         console.log(`Selection from download dropdown '${item.value}' has no action defined.`);
+        setLoading(false);
         break;
     }
   };


### PR DESCRIPTION
**Description of changes**

Fixes bug where clicking on 'Number of selected files' shows loading spinner
Aligns with behaviour used in HCMI & DCC for the same button (menu closes when clicking 'number of files')

**Type of Change**

- [x] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
