### PR TITLE
💄 #521 Default Blue Descending Header Band

### DIFF
--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -194,6 +194,7 @@ const FileTable = () => {
   > = [
     {
       Header: 'File ID',
+      headerClassName: pagingState.sort == DEFAULT_SORT ? '-sort-desc' : '',
       id: FileCentricDocumentField.file_id,
       accessor: 'fileId',
       Cell: ({ original }: { original: FileRepositoryRecord }) => {


### PR DESCRIPTION
**Description of changes**

Adds blue 'descending' header band by default to File ID column on table

https://app.zenhub.com/workspaces/icgc-argo-platform-dk-production-board-5e542d38415f5034e9fed89d/issues/icgc-argo/platform-api/521
See comments in ticket

**Type of Change**

- [ ] Bug
- [x] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [x] No new UIKit components or changes
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Add copyrights to new files
- [x] Connected ticket to PR
