### PR TITLE
Feat/#2002 update daco links

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -9,6 +9,7 @@ FEATURE_ACCESS_FACET_ENABLED=false
 FEATURE_DONOR_ENTITY_ENABLED=true
 FEATURE_FACET_TABS_ENABLED=false
 FEATURE_RNASEQ_ENABLED=false
+FEATURE_DACO_V2_ENABLED=false
 
 # Feature flag for charts on program dashboard
 # (Completed Core Clinical Data & Molecular Data Summary)
@@ -51,3 +52,6 @@ STORYBOOK_GATEWAY_API_ROOT=http://localhost:9000
 
 # File Entity
 MAX_FILE_DOWNLOAD_SIZE=
+
+# DACO
+DACO_URL=''

--- a/global/config.ts
+++ b/global/config.ts
@@ -35,7 +35,7 @@ export const getConfig = () => {
       publicConfig.EGO_API_ROOT || '',
       `/api/oauth/login/google?client_id=${publicConfig.EGO_CLIENT_ID || ''}`,
     ),
-    DACO_URL: publicConfig.DACO_URL || 'https://icgc.org/daco',
+    DACO_URL: publicConfig.DACO_URL || '',
     DOCS_URL_ROOT: publicConfig.DOCS_URL_ROOT || 'https://docs.icgc-argo.org',
     RECAPTCHA_SITE_KEY:
       publicConfig.RECAPTCHA_SITE_KEY || '6Lebz-IUAAAAACY7eMyfK4H52Sxy9hv4FYjhFgSR',
@@ -49,6 +49,7 @@ export const getConfig = () => {
     FEATURE_FACET_TABS_ENABLED: publicConfig.FEATURE_FACET_TABS_ENABLED === 'true',
     MAX_FILE_DOWNLOAD_SIZE: publicConfig.MAX_FILE_DOWNLOAD_SIZE || 5000000, // 5MB
     FEATURE_RNASEQ_ENABLED: publicConfig.FEATURE_RNASEQ_ENABLED === 'true',
+    FEATURE_DACO_V2_ENABLED: publicConfig.FEATURE_DACO_V2_ENABLED === 'true',
   } as {
     GATEWAY_API_ROOT: string;
     EGO_API_ROOT: string;
@@ -70,5 +71,6 @@ export const getConfig = () => {
     FEATURE_FACET_TABS_ENABLED: boolean;
     MAX_FILE_DOWNLOAD_SIZE: number;
     FEATURE_RNASEQ_ENABLED: boolean;
+    FEATURE_DACO_V2_ENABLED: boolean;
   };
 };

--- a/global/constants/docSitePaths.tsx
+++ b/global/constants/docSitePaths.tsx
@@ -19,7 +19,7 @@
 import urljoin from 'url-join';
 import { getConfig } from 'global/config';
 
-const { DOCS_URL_ROOT } = getConfig();
+const { DOCS_URL_ROOT, FEATURE_DACO_V2_ENABLED } = getConfig();
 
 export const DOCS_DICTIONARY_PAGE = urljoin(DOCS_URL_ROOT, `/dictionary/`);
 
@@ -27,7 +27,10 @@ export const DOCS_DNA_PIPELINE_PAGE = urljoin(
   DOCS_URL_ROOT,
   '/docs/analysis-workflows/analysis-overview',
 );
-export const DOCS_DATA_ACCESS_PAGE = urljoin(DOCS_URL_ROOT, '/docs/data-access/data-access');
+export const DOCS_DATA_ACCESS_PAGE = FEATURE_DACO_V2_ENABLED
+  ? urljoin(DOCS_URL_ROOT, '/docs/data-access/daco/applying')
+  : urljoin(DOCS_URL_ROOT, '/docs/data-access/data-access');
+
 export const DOCS_DATA_DOWNLOAD_PAGE = urljoin(DOCS_URL_ROOT, '/docs/data-access/data-download');
 export const DOCS_PROGRAMMATIC_APIS_PAGE = urljoin(
   DOCS_URL_ROOT,


### PR DESCRIPTION
**Description of changes**

- change default for DACO_URL to empty string, configure in environments, otherwise we get env var depending on env vars. explicit is better I think.
- add new feature flag DACO_V2
- update docs path
- update env.schema

**Type of Change**

- [ ] Bug
- [ ] Styling
- [ ] New Feature

**Checklist before requesting review:**

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] New Components with storybook stories created
  - [ ] Modified Existing components and updates stories
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [ ] Manual testing of UI feature
- [ ] Add copyrights to new files
- [ ] Connected ticket to PR
