### PR TITLE
🐛 2215 - Fix invite login

### DIFF
--- a/components/GoogleLoginButton.tsx
+++ b/components/GoogleLoginButton.tsx
@@ -18,25 +18,29 @@
  */
 
 import GoogleLogin from 'uikit/Button/GoogleLogin';
-import useAuthContext from 'global/hooks/useAuthContext';
+import { removeToken } from 'global/hooks/useAuthContext';
 import useFiltersContext from './pages/file-repository/hooks/useFiltersContext';
 
-const GoogleLoginButton: React.ComponentType<
-  React.ComponentProps<typeof GoogleLogin> & {
-    logoutToRoot?: boolean;
-  }
-> = ({ logoutToRoot = false, ...props }) => {
-  const { logOut } = useAuthContext();
+const GoogleLoginButton: React.ComponentType<React.ComponentProps<typeof GoogleLogin>> = ({
+  ...props
+}) => {
   const { clearFilters } = useFiltersContext();
   return (
     <GoogleLogin
       {...props}
       onClick={(e) => {
+        // if there's an existing jwt, the url does not decode properly and the app returns a 404. the browser navigation does not show any platform redirect param
+        // when the jwt is removed first, the redirect parameter shows up properly in the url and navigation to the details page occurs after login
+        // this looks like it is somehow related to the _app auth check + redirect logic, but next returns the /_error path immediately so haven't pinpointed what is happening
+        // for reference:
+        // jwt is removed, this is the url after the browser comes back from google: http://localhost:8080/?redirect=/submission%2Fprogram%2Fjoin%2Fdetails%2F<inviteId>%3FisOauth%3Dtrue
+        // jwt is NOT removed: http://localhost:8080/submission%2Fprogram%2Fjoin%2Fdetails%2F<inviteId>%3FisOauth%3Dtrue
+        // NOTE: the removeToken() fix does not work if the login button is right clicked to open a new tab, user will get a 404 after login as mentioned above
+        removeToken();
         if (props.onClick) {
           props.onClick(e);
         }
         clearFilters();
-        logOut();
       }}
     />
   );

--- a/global/hooks/useAuthContext.tsx
+++ b/global/hooks/useAuthContext.tsx
@@ -51,6 +51,14 @@ const AuthContext = React.createContext<T_AuthContext>({
   isLoggingOut: false,
 });
 
+const setToken = (token: string) => {
+  Cookies.set(EGO_JWT_KEY, token);
+};
+
+export const removeToken = () => {
+  Cookies.remove(EGO_JWT_KEY);
+};
+
 export function AuthProvider({
   egoJwt,
   children,
@@ -70,14 +78,6 @@ export function AuthProvider({
   const [isLoggingOut, setIsLoggingOut] = React.useState(false);
 
   const router = useRouter();
-
-  const setToken = (token: string) => {
-    Cookies.set(EGO_JWT_KEY, token);
-  };
-
-  const removeToken = () => {
-    Cookies.remove(EGO_JWT_KEY);
-  };
 
   const logOut: T_AuthContext['logOut'] = async (path) => {
     // this will be reset to false when user logs in again, and AuthContext is re-instantiated


### PR DESCRIPTION
# Description of changes

Replaces `logout()` call in `GoogleLoginButton` with `removeToken()`, to ensure the jwt is removed but logout router logic is avoided.
This is a simple fix for the immediate issue, but should note that some strange redirect behaviour was found based on whether the user is logged in or not. Adds comments about jwt + redirect behaviour that may need further investigation.

## Type of Change

- [x] Bug
- [ ] Styling
- [ ] New Feature

## Checklist before requesting review

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- UI Kit (select one):
  - [ ] Modified Existing components
  - [ ] No new UIKit components or changes
- [ ] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [x] Connected ticket to PR
