### PR TITLE
Style/2350 submitted data feedback on error display clinical completeness

### DIFF
--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -42,6 +42,7 @@ import {
   CoreCompletionFields,
   defaultClinicalEntityFilters,
   emptyResponse,
+  clinicalEntityDisplayNames,
 } from '../common';
 
 export type DonorEntry = {
@@ -464,7 +465,9 @@ const ClinicalEntityDataTable = ({
         >
           <ErrorNotification
             level={NOTIFICATION_VARIANTS.ERROR}
-            title={`${totalErrors.toLocaleString()} error(s) found in submission workspace`}
+            title={`${totalErrors.toLocaleString()} error(s) found in ${clinicalEntityDisplayNames[
+              entityType
+            ].toLowerCase()} data`}
             subtitle={<Subtitle program={program} />}
             errors={tableErrors}
             columnConfig={errorColumns}

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -328,7 +328,7 @@ const ClinicalEntityDataTable = ({
     records = entityData.records.map((record) => {
       let clinicalRecord = {};
       record.forEach((r) => {
-        clinicalRecord[r.name] = r.value || '--';
+        clinicalRecord[r.name] = r.value || ' ';
         if (completionStats && r.name === 'donor_id') {
           const completion =
             completionStats.find((stat) => stat.donorId === parseInt(r.value))?.coreCompletion ||

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -101,6 +101,8 @@ const NoDataCell = () => (
   </div>
 );
 
+const completionKeys = Object.values(aliasSortNames);
+const completionColumnNames = Object.keys(aliasSortNames);
 const emptyCompletion = {
   DO: 0,
   PD: 0,
@@ -194,7 +196,8 @@ const ClinicalEntityDataTable = ({
   const [errorPageSettings, setErrorPageSettings] = useState(defaultErrorPageSettings);
   const { page: errorPage, pageSize: errorPageSize, sorted: errorSorted } = errorPageSettings;
   const { desc, id } = sorted[0];
-  const sort = `${desc ? '-' : ''}${aliasSortNames[id] || id}`;
+  const sortKey = aliasSortNames[id] || id;
+  const sort = `${desc ? '-' : ''}${sortKey}`;
 
   const latestDictionaryResponse = useClinicalSubmissionSchemaVersion();
 
@@ -281,6 +284,42 @@ const ClinicalEntityDataTable = ({
     };
   });
 
+  const sortEntityData = (prev, next) => {
+    let sortVal = 0;
+
+    if (hasErrors) {
+      // If Current Entity has Errors, Prioritize Data w/ Errors
+      const { errorsA, errorsB } = clinicalErrors.reduce(
+        (acc, current) => {
+          if (current.donorId == prev['donor_id']) {
+            acc.errorsA = -1;
+          }
+          if (current.donorId == next['donor_id']) {
+            acc.errorsB = 1;
+          }
+          return acc;
+        },
+        { errorsA: 0, errorsB: 0 },
+      );
+
+      sortVal += errorsA + errorsB;
+    }
+
+    // Handles Manual User Sorting by Core Completion columns
+    const completionSortIndex = completionKeys.indexOf(sortKey);
+
+    if (completionSortIndex) {
+      const completionSortKey = completionColumnNames[completionSortIndex];
+      const completionA = prev[completionSortKey];
+      const completionB = next[completionSortKey];
+
+      sortVal = completionA === completionB ? 0 : completionA > completionB ? -1 : 1;
+      sortVal *= desc ? -1 : 1;
+    }
+
+    return sortVal;
+  };
+
   // Map Completion Stats + Entity Data
   if (noData) {
     showCompletionStats = true;
@@ -295,7 +334,6 @@ const ClinicalEntityDataTable = ({
     showCompletionStats = !!(completionStats && entityName === aliasedEntityNames.donor);
 
     totalDocs = entityData.totalDocs;
-
     entityData.records.forEach((record) => {
       record.forEach((r) => {
         if (!columns.includes(r.name)) columns.push(r.name);
@@ -499,6 +537,7 @@ const ClinicalEntityDataTable = ({
         page={page}
         pages={numTablePages}
         pageSize={pageSize}
+        defaultSortMethod={sortEntityData}
         sorted={sorted}
         getTdProps={getCellStyles}
         columns={columns}

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -101,10 +101,7 @@ const NoDataCell = () => (
       padding: 80px 0;
     `}
   >
-    <ContentPlaceholder
-      title="You do not have any data uploaded."
-      subtitle="Follow the instructions above to get started."
-    >
+    <ContentPlaceholder title="No Data Found.">
       <img alt="No Data" src={noDataSvg} />
     </ContentPlaceholder>
   </div>
@@ -280,11 +277,10 @@ const ClinicalEntityDataTable = ({
   const hasErrors = totalErrors > 0;
   const tableErrors = tableErrorGroups.map((errorGroup) => {
     const entries = errorGroup.length;
-    const { errorType, fieldName, entityName, message } = errorGroup[0];
+    const { fieldName, entityName, message } = errorGroup[0];
 
     return {
       entries,
-      errorType,
       fieldName,
       entityName,
       message,

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -303,7 +303,7 @@ const ClinicalEntityDataTable = ({
   if (noData) {
     showCompletionStats = true;
     // Empty string column holds No Data image
-    columns = ['donor_id', ...Object.values(completionColumnHeaders), ' '];
+    // columns = ['donor_id', ...Object.values(completionColumnHeaders), ' '];
 
     records = noDataCompletionStats;
   } else {
@@ -402,7 +402,7 @@ const ClinicalEntityDataTable = ({
     };
 
     columns = [
-      {
+      !noData && {
         Header: (
           <div
             css={css`
@@ -447,23 +447,21 @@ const ClinicalEntityDataTable = ({
         Header: (
           <div
             css={css`
-              position: absolute;
-              left: 20px;
+              width: 100%;
+              text-align: left;
+              padding-left: 5px;
             `}
           >
             SUBMITTED DONOR DATA
           </div>
         ),
         headerStyle: dataHeaderStyle,
-        columns: columns.slice(7).map((column, i) =>
-          noData
-            ? {
-                Cell: <NoDataCell />,
-              }
-            : column,
-        ),
+
+        ...(noData
+          ? { Cell: <NoDataCell /> }
+          : { columns: columns.slice(7).map((column, i) => column) }),
       },
-    ];
+    ].filter((x) => x); // removes falsy element when there is no data
   }
 
   const tableMin = totalDocs > 0 ? page * pageSize + 1 : totalDocs;

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -48,6 +48,8 @@ import {
 import { useClinicalSubmissionSchemaVersion } from 'global/hooks/useClinicalSubmissionSchemaVersion';
 import { DOCS_DICTIONARY_PAGE } from 'global/constants/docSitePaths';
 
+import { PROGRAM_SHORT_NAME_PATH, PROGRAM_CLINICAL_SUBMISSION_PATH } from 'global/constants/pages';
+
 export type DonorEntry = {
   row: string;
   isNew: boolean;
@@ -208,8 +210,6 @@ const ClinicalEntityDataTable = ({
 
   const latestDictionaryResponse = useClinicalSubmissionSchemaVersion();
 
-  console.log('lastestDictionaryResponse.loading', latestDictionaryResponse.loading);
-
   const Subtitle = (program) => (
     <div
       css={css`
@@ -222,9 +222,14 @@ const ClinicalEntityDataTable = ({
       </Link>{' '}
       of the data dictionary was released and has made some donors invalid. Please download the
       error report to view the affected donors, then submit a corrected TSV file in the{' '}
-      <Link href={`/submission/program/${program}/clinical-submission?tab=donor`}>
-        Submit Clinical Data
-      </Link>{' '}
+      <Link
+        href={PROGRAM_CLINICAL_SUBMISSION_PATH.replace(
+          PROGRAM_SHORT_NAME_PATH,
+          program.program as string,
+        )}
+      >
+        Submit Clinical Data{' '}
+      </Link>
       workspace.
     </div>
   );

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -69,12 +69,12 @@ const errorColumns = [
     id: 'fieldName',
     maxWidth: 215,
   },
-  {
-    accessor: 'errorType',
-    Header: 'Error Value',
-    id: 'errorType',
-    maxWidth: 185,
-  },
+  // {
+  //   accessor: 'errorType',
+  //   Header: 'Error Value',
+  //   id: 'errorType',
+  //   maxWidth: 185,
+  // },
   {
     accessor: 'message',
     Header: `Error Description`,

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -59,7 +59,7 @@ export type DonorEntry = {
 const errorColumns = [
   {
     accessor: 'entries',
-    Header: '# Affected Donors',
+    Header: '# Affected Records',
     id: 'entries',
     maxWidth: 135,
   },

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -49,6 +49,7 @@ import { useClinicalSubmissionSchemaVersion } from 'global/hooks/useClinicalSubm
 import { DOCS_DICTIONARY_PAGE } from 'global/constants/docSitePaths';
 
 import { PROGRAM_SHORT_NAME_PATH, PROGRAM_CLINICAL_SUBMISSION_PATH } from 'global/constants/pages';
+import ContentPlaceholder from '@icgc-argo/uikit/ContentPlaceholder';
 
 export type DonorEntry = {
   row: string;
@@ -91,26 +92,22 @@ const Container = styled('div')`
 `;
 
 const NoDataCell = () => (
-  <Container>
-    <img
-      css={css`
-        height: 75px;
-      `}
-      src={noDataSvg}
-    />
-    <Typography
-      css={css`
-        margin-top: 14px;
-        margin-bottom: 0;
-      `}
-      color="grey"
-      variant="data"
-      as="p"
-      bold
+  <div
+    css={css`
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 80px 0;
+    `}
+  >
+    <ContentPlaceholder
+      title="You do not have any data uploaded."
+      subtitle="Follow the instructions above to get started."
     >
-      No Data Found
-    </Typography>
-  </Container>
+      <img alt="No Data" src={noDataSvg} />
+    </ContentPlaceholder>
+  </div>
 );
 
 const emptyCompletion = {
@@ -210,7 +207,7 @@ const ClinicalEntityDataTable = ({
 
   const latestDictionaryResponse = useClinicalSubmissionSchemaVersion();
 
-  const Subtitle = (program) => (
+  const Subtitle = ({ program = '' }) => (
     <div
       css={css`
         margin-bottom: 12px;
@@ -222,12 +219,7 @@ const ClinicalEntityDataTable = ({
       </Link>{' '}
       of the data dictionary was released and has made some donors invalid. Please download the
       error report to view the affected donors, then submit a corrected TSV file in the{' '}
-      <Link
-        href={PROGRAM_CLINICAL_SUBMISSION_PATH.replace(
-          PROGRAM_SHORT_NAME_PATH,
-          program.program as string,
-        )}
-      >
+      <Link href={PROGRAM_CLINICAL_SUBMISSION_PATH.replace(PROGRAM_SHORT_NAME_PATH, program)}>
         Submit Clinical Data{' '}
       </Link>
       workspace.
@@ -402,7 +394,7 @@ const ClinicalEntityDataTable = ({
     };
 
     columns = [
-      !noData && {
+      {
         Header: (
           <div
             css={css`
@@ -456,12 +448,9 @@ const ClinicalEntityDataTable = ({
           </div>
         ),
         headerStyle: dataHeaderStyle,
-
-        ...(noData
-          ? { Cell: <NoDataCell /> }
-          : { columns: columns.slice(7).map((column, i) => column) }),
+        columns: columns.slice(7).map((column, i) => column),
       },
-    ].filter((x) => x); // removes falsy element when there is no data
+    ];
   }
 
   const tableMin = totalDocs > 0 ? page * pageSize + 1 : totalDocs;
@@ -471,6 +460,8 @@ const ClinicalEntityDataTable = ({
 
   return loading ? (
     <DnaLoader />
+  ) : noData ? (
+    <NoDataCell />
   ) : (
     <div
       ref={containerRef}

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -45,6 +45,9 @@ import {
   clinicalEntityDisplayNames,
 } from '../common';
 
+import { useClinicalSubmissionSchemaVersion } from 'global/hooks/useClinicalSubmissionSchemaVersion';
+import { DOCS_DICTIONARY_PAGE } from 'global/constants/docSitePaths';
+
 export type DonorEntry = {
   row: string;
   isNew: boolean;
@@ -124,22 +127,6 @@ const noDataCompletionStats = [
   },
 ];
 
-const Subtitle = (program) => (
-  <div
-    css={css`
-      margin-bottom: 12px;
-    `}
-  >
-    <Link href="https://docs.icgc-argo.org/dictionary">Version 1.13</Link> of the data dictionary
-    was released and has made some donors invalid. Please download the error report to view the
-    affected donors, then submit a corrected TSV file in the{' '}
-    <Link href={`/submission/program/${program}/clinical-submission?tab=donor`}>
-      Submit Clinical Data
-    </Link>{' '}
-    workspace.
-  </div>
-);
-
 const completionColumnHeaders = {
   donor: 'DO',
   primaryDiagnosis: 'PD',
@@ -218,6 +205,29 @@ const ClinicalEntityDataTable = ({
   const { page: errorPage, pageSize: errorPageSize, sorted: errorSorted } = errorPageSettings;
   const { desc, id } = sorted[0];
   const sort = `${desc ? '-' : ''}${aliasSortNames[id] || id}`;
+
+  const latestDictionaryResponse = useClinicalSubmissionSchemaVersion();
+
+  console.log('lastestDictionaryResponse.loading', latestDictionaryResponse.loading);
+
+  const Subtitle = (program) => (
+    <div
+      css={css`
+        margin-bottom: 12px;
+      `}
+    >
+      <Link target="_blank" href={DOCS_DICTIONARY_PAGE}>
+        {!latestDictionaryResponse.loading &&
+          `Version ${latestDictionaryResponse.data.clinicalSubmissionSchemaVersion}`}
+      </Link>{' '}
+      of the data dictionary was released and has made some donors invalid. Please download the
+      error report to view the affected donors, then submit a corrected TSV file in the{' '}
+      <Link href={`/submission/program/${program}/clinical-submission?tab=donor`}>
+        Submit Clinical Data
+      </Link>{' '}
+      workspace.
+    </div>
+  );
 
   const updatePageSettings = (key, value) => {
     const newPageSettings = { ...pageSettings, [key]: value };

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -444,7 +444,16 @@ const ClinicalEntityDataTable = ({
         })),
       },
       {
-        Header: 'SUBMITTED DONOR DATA',
+        Header: (
+          <div
+            css={css`
+              position: absolute;
+              left: 20px;
+            `}
+          >
+            SUBMITTED DONOR DATA
+          </div>
+        ),
         headerStyle: dataHeaderStyle,
         columns: columns.slice(7).map((column, i) =>
           noData

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -322,7 +322,6 @@ const ClinicalEntityDataTable = ({
   // Map Completion Stats + Entity Data
   if (noData) {
     showCompletionStats = true;
-    // Empty string column holds No Data image
     records = noDataCompletionStats;
   } else {
     const entityData = clinicalData.clinicalEntities.find(

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -70,12 +70,6 @@ const errorColumns = [
     id: 'fieldName',
     maxWidth: 215,
   },
-  // {
-  //   accessor: 'errorType',
-  //   Header: 'Error Value',
-  //   id: 'errorType',
-  //   maxWidth: 185,
-  // },
   {
     accessor: 'message',
     Header: `Error Description`,
@@ -291,8 +285,6 @@ const ClinicalEntityDataTable = ({
   if (noData) {
     showCompletionStats = true;
     // Empty string column holds No Data image
-    // columns = ['donor_id', ...Object.values(completionColumnHeaders), ' '];
-
     records = noDataCompletionStats;
   } else {
     const entityData = clinicalData.clinicalEntities.find(
@@ -313,26 +305,27 @@ const ClinicalEntityDataTable = ({
       columns.splice(1, 0, ...Object.values(completionColumnHeaders));
     }
 
-    records = entityData.records.map((record) => {
-      let clinicalRecord = {};
-      record.forEach((r) => {
-        clinicalRecord[r.name] = r.value || ' ';
-        if (completionStats && r.name === 'donor_id') {
-          const completion =
-            completionStats.find((stat) => stat.donorId === parseInt(r.value))?.coreCompletion ||
-            emptyCompletion;
+    records = entityData.records
+      .map((record) => {
+        let clinicalRecord = {};
+        record.forEach((r) => {
+          clinicalRecord[r.name] = r.value || '';
+          if (completionStats && r.name === 'donor_id') {
+            const completion =
+              completionStats.find((stat) => stat.donorId === parseInt(r.value))?.coreCompletion ||
+              emptyCompletion;
+            CoreCompletionFields.forEach((field) => {
+              const completionField = completionColumnHeaders[field];
+              clinicalRecord[completionField] = completion[field] || 0;
+            });
 
-          CoreCompletionFields.forEach((field) => {
-            const completionField = completionColumnHeaders[field];
-            clinicalRecord[completionField] = completion[field] || 0;
-          });
+            clinicalRecord = { ...clinicalRecord, ...completion };
+          }
+        });
 
-          clinicalRecord = { ...clinicalRecord, ...completion };
-        }
-      });
-
-      return clinicalRecord;
-    });
+        return clinicalRecord;
+      })
+      .sort(sortEntityData);
   }
 
   const getHeaderBorder = (key) =>
@@ -381,7 +374,8 @@ const ClinicalEntityDataTable = ({
     };
 
     const dataHeaderStyle = {
-      textAlign: 'center',
+      textAlign: 'left',
+      paddingLeft: '6px',
     };
 
     const noDataCellStyle = {
@@ -432,17 +426,7 @@ const ClinicalEntityDataTable = ({
         })),
       },
       {
-        Header: (
-          <div
-            css={css`
-              width: 100%;
-              text-align: left;
-              padding-left: 5px;
-            `}
-          >
-            SUBMITTED DONOR DATA
-          </div>
-        ),
+        Header: <div>SUBMITTED DONOR DATA</div>,
         headerStyle: dataHeaderStyle,
         columns: columns.slice(7).map((column, i) => column),
       },


### PR DESCRIPTION
# Description of changes

<!-- UI fixes 
         - error banner title shows entity name
         - error banner shows current dictionary number version and provides the link to dictionary
         - error banner second link to the Submit Clinical Data page is fixed
         - error table's column title, '# Affected Records' is changed to '# Affected Donors'
         - error table's column, 'Error Value' is removed
         - submitted table shows blank cells instead of '--' 
         - submitted table's title, 'Submitted Donor Data' is shifted to the left 
         - when there is no data, the table on the left side and boarder are removed. Only a 'No Data Found.' and file icon is showing -->

## Type of Change

- [x] Bug
- [x] Styling

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- [x] Feature is minimally responsive
- [x] Manual testing of UI feature
- [ ] Add copyrights to new files
- [x] Connected ticket to PR
