### PR TITLE
#2374 Feature Request - Make Donor Id Column visible All the Time

### DIFF
--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -373,10 +373,11 @@ const ClinicalEntityDataTable = ({
       ? `3px solid ${theme.colors.grey}`
       : '';
 
+  const [stickyDonorIDColumnsWidth, setStickyDonorIDColumnsWidth] = useState(74);
+
   const getCellStyles = (state, row, column) => {
     const { original } = row;
-    const { id } = column;
-
+    const { id, ...others } = column;
     const isCompletionCell =
       showCompletionStats && Object.values(completionColumnHeaders).includes(id);
 
@@ -423,6 +424,17 @@ const ClinicalEntityDataTable = ({
         color: isCompletionCell && !errorState ? theme.colors.accent1_dark : '',
         background: errorState ? theme.colors.error_4 : '',
         borderRight: border,
+        ...(column.Header === 'donor_id' && {
+          background: 'white',
+          position: 'absolute',
+        }),
+        ...(column.Header === 'DO' && {
+          marginLeft: stickyDonorIDColumnsWidth,
+        }),
+        ...(column.Header === 'program_id' &&
+          !showCompletionStats && {
+            marginLeft: stickyDonorIDColumnsWidth,
+          }),
       },
     };
   };
@@ -434,6 +446,19 @@ const ClinicalEntityDataTable = ({
       Header: key,
       headerStyle: {
         borderRight: getHeaderBorder(key),
+        ...(key === 'donor_id' && {
+          position: 'absolute',
+          //z-index used here because header element is beneath its neighbouring element.
+          zIndex: 1,
+          background: 'white',
+        }),
+        ...(key === 'DO' && {
+          marginLeft: stickyDonorIDColumnsWidth,
+        }),
+        ...(key === 'program_id' &&
+          !showCompletionStats && {
+            marginLeft: stickyDonorIDColumnsWidth,
+          }),
       },
       minWidth: getColumnWidth(key, showCompletionStats, noData),
     };
@@ -584,6 +609,11 @@ const ClinicalEntityDataTable = ({
         onPageChange={(value) => updatePageSettings('page', value)}
         onPageSizeChange={(value) => updatePageSettings('pageSize', value)}
         onSortedChange={(value) => updatePageSettings('sorted', value)}
+        onResizedChange={(newResized) => {
+          newResized.forEach(
+            (column) => column.id === 'donor_id' && setStickyDonorIDColumnsWidth(column.value),
+          );
+        }}
       />
     </div>
   );

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -377,7 +377,7 @@ const ClinicalEntityDataTable = ({
 
   const getCellStyles = (state, row, column) => {
     const { original } = row;
-    const { id, ...others } = column;
+    const { id } = column;
     const isCompletionCell =
       showCompletionStats && Object.values(completionColumnHeaders).includes(id);
 


### PR DESCRIPTION
# Description of changes

<!--  Make `donor-id` column of the Clinical Submitted Page table always visible by applying CSS to this column and its neighbouring column. -->

## Type of Change

- [x] Styling

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- [ ] Feature is minimally responsive
- [x] Manual testing of UI feature
- [x] Connected ticket to PR

Original Appearance of Clinical Submitted Page Table (There are two types of table on this page. This type has two titles)
![Screen Shot 2022-09-01 at 11 31 03 AM](https://user-images.githubusercontent.com/79996555/187954924-c5027310-a4b6-496a-9fd9-4212fc2a535b.png)

Scroll to the Right of Table and `donor_id` Column Will Follow
![Screen Shot 2022-09-01 at 11 31 20 AM](https://user-images.githubusercontent.com/79996555/187955164-e46d0841-1566-4e84-86bb-0b669ea74762.png)

Width Change of `donor_id` Column Won't Cover Up Nor Affect the Alignment of the Rest of the Table
![Screen Shot 2022-09-01 at 11 31 43 AM](https://user-images.githubusercontent.com/79996555/187955449-42b3ef13-b4e1-46e1-9cad-c0b4a5d6e235.png)

Change the Width of `donor_id` Column and Scroll to the Right
![Screen Shot 2022-09-01 at 11 32 06 AM](https://user-images.githubusercontent.com/79996555/187956147-d0ab3f98-92af-48c7-9ec5-2b26e9c13257.png)

The Same Function Works on the Second Type of Table (Table with one title)
![Screen Shot 2022-09-01 at 11 34 51 AM](https://user-images.githubusercontent.com/79996555/187956667-cd2cdb60-8635-4ab5-9e73-8408bd6f161f.png)



