### PR TITLE
#2483: add no verify to QA git push

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -115,6 +115,7 @@ spec:
                     withCredentials([usernamePassword(credentialsId: 'argoGithub', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
                         sh "git tag ${version}"
                         sh "git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${githubRepo} --tags --no-verify"
+                        // added --no-verify to skip husky checks. see issue #2483
                     }
                     withCredentials([usernamePassword(credentialsId:'argoContainers', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                         sh "docker login ${dockerRegistry} -u $USERNAME -p $PASSWORD"

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -114,7 +114,7 @@ spec:
                 container('docker') {
                     withCredentials([usernamePassword(credentialsId: 'argoGithub', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
                         sh "git tag ${version}"
-                        sh "git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${githubRepo} --tags"
+                        sh "git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${githubRepo} --tags --no-verify"
                     }
                     withCredentials([usernamePassword(credentialsId:'argoContainers', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
                         sh "docker login ${dockerRegistry} -u $USERNAME -p $PASSWORD"


### PR DESCRIPTION
# Description of changes

- add `--no-verify` when Jenkins makes commits for QA builds
- this is to fix the issue where Jenkins can't find NPM
- this is **temporary fix** so we can do a QA release this week.

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [x] No back-end changes
- [x] Manually tested changes
- [x] Added copyrights to new files
- [x] Connected ticket to PR
