### PR TITLE
Style/2458 QA favicon missing

### DIFF
--- a/components/Head.tsx
+++ b/components/Head.tsx
@@ -22,7 +22,7 @@ import NextHead from 'next/head';
 export default function Head() {
   return (
     <NextHead>
-      <link rel="icon" href="/public/favicon.ico" />
+      <link rel="icon" href="/favicon.ico" />
     </NextHead>
   );
 }


### PR DESCRIPTION
# Description of changes

favicon which is the icon in the browser tab is missing. The directory of use to obtain the image file is updated and issue solved.

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [ ] No back-end changes
- [x] Manually tested changes
- [ ] Added copyrights to new files
- [ ] Connected ticket to PR

works in Chrome tab
<img width="320" alt="Screenshot 2022-11-30 at 10 03 13 AM" src="https://user-images.githubusercontent.com/79996555/204861422-cd6116ec-0237-4e42-819d-a3635615c147.png">

works in Firefox tab
<img width="324" alt="Screenshot 2022-11-30 at 10 03 22 AM" src="https://user-images.githubusercontent.com/79996555/204861454-44af5fb1-61ac-43b5-bf6d-59ee239455f3.png">


