### PR TITLE
Issue#2240: File Entity page: doc links update for new RNA workflows

### DIFF
--- a/components/pages/file-entity/DataAndAnalysis/index.tsx
+++ b/components/pages/file-entity/DataAndAnalysis/index.tsx
@@ -18,7 +18,15 @@
  */
 
 import { css, Link, SimpleTable, useTheme } from '@icgc-argo/uikit';
-import { WORKFLOW_NAMES, WORKFLOW_NAME_URLS, WORKFLOW_VERSION_URLS } from 'global/constants';
+import {
+  WORKFLOW_NAMES,
+  WORKFLOW_NAME_URLS,
+  WORKFLOW_VERSION_URLS,
+  GENOME_BUILD,
+  GENOME_BUILD_URL,
+  GENOME_ANNOTATION,
+  GENOME_ANNOTATION_URL,
+} from 'global/constants';
 import { FileCard, TableDiv } from '../common';
 import { DataAnalysisInfo, DataAnalysisWorkflowType } from '../types';
 
@@ -60,6 +68,13 @@ const getWorkflowNameLink = (workflowType: DataAnalysisWorkflowType) => {
           {workflowType.workflow_name}
         </Link>
       );
+    // case for rnaseq worlflow url. url not ready yet.
+    // case WORKFLOW_NAMES.rnaSeq:
+    //   return (
+    //     <Link href={WORKFLOW_NAME_URLS.rnaSeq} target="_blank">
+    //       {workflowType.workflow_name}
+    //     </Link>
+    //   );
     default:
       return workflowType.workflow_name;
   }
@@ -114,15 +129,63 @@ const getWorkflowVersionLink = (workflowType: DataAnalysisWorkflowType) => {
           {workflowType.workflow_version}
         </Link>
       );
+    case WORKFLOW_NAMES.rnaSeq:
+      return (
+        <Link
+          href={`${WORKFLOW_VERSION_URLS.rnaSeq}${workflowType.workflow_version}`}
+          target="_blank"
+        >
+          {workflowType.workflow_version}
+        </Link>
+      );
     default:
       return workflowType.workflow_version;
   }
 };
 
-// Hard-coded Genome Build as per: https://github.com/icgc-argo/platform-ui/issues/2105
-const GENOME_BUILD = 'GRCh38DH';
-const GENOME_BUILD_URL =
-  'http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome';
+const getGenomeBuild = (workflowType: DataAnalysisWorkflowType) => {
+  if (!workflowType || !workflowType.workflow_name) return null;
+
+  switch (workflowType.workflow_name) {
+    case WORKFLOW_NAMES.rnaSeq:
+      return (
+        <Link href={GENOME_BUILD_URL.rnaSeq} target="_blank">
+          {GENOME_BUILD.rnaSeq}
+        </Link>
+      );
+    default:
+      return (
+        <Link href={GENOME_BUILD_URL.default} target="_blank">
+          {GENOME_BUILD.default}
+        </Link>
+      );
+  }
+};
+
+const getGenomeAnnotation = (workflowType: DataAnalysisWorkflowType) => {
+  if (!workflowType || !workflowType.workflow_name) return null;
+
+  switch (workflowType.workflow_name) {
+    case WORKFLOW_NAMES.rnaSeq:
+      return (
+        <Link href={GENOME_ANNOTATION_URL.rnaSeq} target="_blank">
+          {GENOME_ANNOTATION.rnaSeq}
+        </Link>
+      );
+    default:
+      const theme = useTheme();
+      return (
+        <div
+          css={css`
+            font-style: italic;
+            color: ${theme.colors.grey};
+          `}
+        >
+          N/A
+        </div>
+      );
+  }
+};
 
 const DataAndAnalysis = ({ data }: { data: DataAnalysisInfo }) => {
   const theme = useTheme();
@@ -132,21 +195,8 @@ const DataAndAnalysis = ({ data }: { data: DataAnalysisInfo }) => {
     'Data Category': data.dataCategory,
     'Data Type': data.dataType,
     Platform: data.platform,
-    'Genome Build': (
-      <Link href={GENOME_BUILD_URL} target="_blank">
-        {GENOME_BUILD}
-      </Link>
-    ),
-    'Genome Annotation': (
-      <div
-        css={css`
-          font-style: italic;
-          color: ${theme.colors.grey};
-        `}
-      >
-        N/A
-      </div>
-    ),
+    'Genome Build': getGenomeBuild(data.workflowType),
+    'Genome Annotation': getGenomeAnnotation(data.workflowType),
     'Workflow Name': getWorkflowNameLink(data.workflowType),
     'Workflow Version': getWorkflowVersionLink(data.workflowType),
     'Analysis Tools':

--- a/global/constants/index.tsx
+++ b/global/constants/index.tsx
@@ -370,6 +370,7 @@ export const WORKFLOW_NAMES = {
   sangerWxs: 'Sanger WXS Variant Calling',
   mutect2: 'GATK Mutect2 Variant Calling',
   openAccess: 'Open Access Variant Filtering',
+  rnaSeq: 'RNA Seq Alignment',
 };
 
 export const WORKFLOW_NAME_URLS = {
@@ -378,6 +379,7 @@ export const WORKFLOW_NAME_URLS = {
   sangerWxs: 'https://docs.icgc-argo.org/docs/analysis-workflows/dna-sanger-wxs-vc',
   mutect2: 'https://docs.icgc-argo.org/docs/analysis-workflows/dna-gatk-mutect2-vc',
   openAccess: 'https://docs.icgc-argo.org/docs/analysis-workflows/dna-open-access-filtering',
+  rnaSeq: 'https://docs.icgc-argo.org/docs/analysis-workflows/rna-alignment',
 };
 
 export const WORKFLOW_VERSION_URLS = {
@@ -386,4 +388,25 @@ export const WORKFLOW_VERSION_URLS = {
   sangerWxs: 'https://github.com/icgc-argo-workflows/sanger-wxs-variant-calling/releases/tag/',
   mutect2: 'https://github.com/icgc-argo-workflows/gatk-mutect2-variant-calling/releases/tag/',
   openAccess: 'https://github.com/icgc-argo-workflows/open-access-variant-filtering/releases/tag/',
+  //RNA-SEQ Page doesn't exist as of Dec. 6th 2022.
+  rnaSeq: 'https://github.com/icgc-argo-workflows/rna-seq-alignment/releases/tag/',
+};
+
+export const GENOME_BUILD = {
+  default: 'GRCh38DH',
+  rnaSeq: 'GRCh38_Verily_v1',
+};
+
+export const GENOME_BUILD_URL = {
+  default: 'http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome',
+  rnaSeq:
+    'https://console.cloud.google.com/storage/browser/genomics-public-data/references/GRCh38_Verily',
+};
+
+export const GENOME_ANNOTATION = {
+  rnaSeq: 'GENCODE v40',
+};
+export const GENOME_ANNOTATION_URL = {
+  rnaSeq:
+    'https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_40/gencode.v40.chr_patch_hapl_scaff.annotation.gtf.gz',
 };


### PR DESCRIPTION
# Description of changes

Update names and links of `Genome Build`, `Genome Annotation`, `Workflow Version` for a new Workflow Type, "RNA Seq Alignment". 

## Type of Change

- [ ] Bug
- [ ] Dependency updates
- [x] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [x] No back-end changes
- [x] Manually tested changes
- [ ] Added copyrights to new files
- [x] Connected ticket to PR

When Workflow Name is "RNA Seq Alignment", `Genome Build`, `Genome Annotation` and `Workflow Version` is updated to values specific to this Workflow Name:
<img width="554" alt="Screenshot 2022-12-06 at 1 00 46 PM" src="https://user-images.githubusercontent.com/79996555/205990787-e03da789-f6cc-4167-97b7-ff23503d2744.png">

Link to Genome Build, "GRCh38_Verily_v1" (open in a new tab)
<img width="966" alt="Screenshot 2022-12-06 at 1 01 36 PM" src="https://user-images.githubusercontent.com/79996555/205991237-b4eb8a77-bb01-4911-8bb8-74c91e48b0b2.png">

File downloaded with Genome Annotation link, "GENCODE v40" 
<img width="323" alt="Screenshot 2022-12-06 at 1 02 09 PM" src="https://user-images.githubusercontent.com/79996555/205991465-f195f0a2-bfac-4b60-b979-4ea26e864fd6.png">

Link to Workflow Version, dynamic to tag number. In this case, 0.1.1
<img width="676" alt="Screenshot 2022-12-06 at 1 02 21 PM" src="https://user-images.githubusercontent.com/79996555/205991756-abe9111b-7ab8-466a-99b4-d292f7dde416.png">

