### PR TITLE
#2457: molecular chart display bug

### DIFF
--- a/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
@@ -156,9 +156,15 @@ const LineChart = ({
         points: dataItem.buckets
           .map((dataBucket: DataBucket, i: number) => {
             const xCoordinate = getX(i);
-            const yCoordinate = Math.floor(
-              chartHeight - topPadding / 2 - (dataBucket.donors / maxY) * chartHeight + padding / 2,
-            );
+            const yCoordinate =
+              Math.floor(
+                chartHeight -
+                  topPadding / 2 -
+                  (dataBucket.donors / maxY) * chartHeight +
+                  padding / 2 +
+                  3,
+              ) + 0.5;
+            // add 0.5 to make line sharp
             return `${xCoordinate},${yCoordinate}`;
           })
           .join(' '),
@@ -197,9 +203,8 @@ const LineChart = ({
   );
 
   const YAxisThresholdLine = () => {
-    const yCoordinate = Math.floor(
-      topPadding + ((maxY - yAxisThreshold || 0) / maxY) * chartHeight,
-    );
+    const yCoordinate =
+      Math.floor(topPadding + ((maxY - yAxisThreshold || 0) / maxY) * chartHeight) + 1;
 
     return (
       <TextStyleGroup>
@@ -306,7 +311,7 @@ const LineChart = ({
       <g fill="none" stroke={options.colors.axisBorder} strokeWidth={options.strokeWidth}>
         {new Array(numberOfHorizontalGuides).fill(0).map((guidesValue: number, index: number) => {
           const ratio = (index + 1) / numberOfHorizontalGuides;
-          const yCoordinate = chartHeight - chartHeight * ratio + topPadding;
+          const yCoordinate = Math.floor(chartHeight - chartHeight * ratio + topPadding) + 1;
           return (
             <polyline
               key={yCoordinate}

--- a/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
@@ -105,7 +105,10 @@ const LineChart = ({
     font-size: ${options.fontSize}px;
   `;
   // setup Y axis
-  const maxY = Math.max(yAxisThreshold, getMaxY(data));
+  // round up max Y value so it's a multiple of numberOfHorizontalGuides
+  const roundForHorizontalGuides = (x: number) =>
+    Math.ceil(x / numberOfHorizontalGuides) * numberOfHorizontalGuides;
+  const maxY = roundForHorizontalGuides(Math.max(yAxisThreshold, getMaxY(data)));
   const yAxisDigits = parseFloat(maxY.toString()).toFixed(precision).length + 1;
 
   // setup chart dimensions


### PR DESCRIPTION
# Description of changes

- round up Y axis labels to be multiples of the number of horizontal guides
- tweak positioning of Y axis coordinates

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [x] No back-end changes
- [x] Manually tested changes
- [x] Added copyrights to new files
- [x] Connected ticket to PR
