### PR TITLE
#2456: fix pagination in Donor Summary Table

### DIFF
--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTable.tsx
@@ -466,7 +466,7 @@ const DonorSummaryTable = ({
         const currentDonor = clinicalErrorData.clinicalData.clinicalErrors.find(
           (donor) => donorId === donor.donorId,
         );
-        const entity = currentDonor.errors[0].entityName;
+        const entity = currentDonor?.errors[0].entityName;
         return { donorId, entity };
       })
     : [];


### PR DESCRIPTION
# Description of changes

Add optional chaining so donors without this alert don't break the table when the page size is changed.

![image](https://user-images.githubusercontent.com/3540896/206573067-ff546962-642d-49c2-986b-ba7d49c33b2e.png)

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [x] No back-end changes
- [x] Manually tested changes
- [x] Added copyrights to new files
- [x] Connected ticket to PR

https://app.zenhub.com/workspaces/icgc-argo-platform-dk-production-board-5e542d38415f5034e9fed89d/issues/icgc-argo/platform-ui/2456
