### PR TITLE
#2457: bug: fix Y axis positioning

### DIFF
--- a/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
@@ -112,7 +112,8 @@ const LineChart = ({
   const yAxisDigits = parseFloat(maxY.toString()).toFixed(precision).length + 1;
   // 4-digit Y axis values push the chart lines down by 2 pixels.
   // this value adjusts their positioning.
-  const yAxisAdjustment = maxY.toString().length > 3 ? maxY.toString().length - 2 : 0;
+  const maxYLength = maxY.toString().length;
+  const yAxisAdjustment = maxYLength > 3 ? maxYLength - 2 : 0;
 
   // setup chart dimensions
   const padding = (options.fontSize + yAxisDigits) * 3;

--- a/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
@@ -110,6 +110,9 @@ const LineChart = ({
     Math.ceil(x / numberOfHorizontalGuides) * numberOfHorizontalGuides;
   const maxY = roundForHorizontalGuides(Math.max(yAxisThreshold, getMaxY(data)));
   const yAxisDigits = parseFloat(maxY.toString()).toFixed(precision).length + 1;
+  // 4-digit Y axis values push the chart lines down by 2 pixels.
+  // this value adjusts their positioning.
+  const yAxisAdjustment = maxY.toString().length > 3 ? 2 : 0;
 
   // setup chart dimensions
   const padding = (options.fontSize + yAxisDigits) * 3;
@@ -162,7 +165,8 @@ const LineChart = ({
                   topPadding / 2 -
                   (dataBucket.donors / maxY) * chartHeight +
                   padding / 2 +
-                  3,
+                  3 -
+                  yAxisAdjustment,
               ) + 0.5;
             // add 0.5 to make line sharp
             return `${xCoordinate},${yCoordinate}`;

--- a/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
+++ b/components/pages/submission-system/program-dashboard/ClinicalChart/LineChart/index.tsx
@@ -112,7 +112,7 @@ const LineChart = ({
   const yAxisDigits = parseFloat(maxY.toString()).toFixed(precision).length + 1;
   // 4-digit Y axis values push the chart lines down by 2 pixels.
   // this value adjusts their positioning.
-  const yAxisAdjustment = maxY.toString().length > 3 ? 2 : 0;
+  const yAxisAdjustment = maxY.toString().length > 3 ? maxY.toString().length - 2 : 0;
 
   // setup chart dimensions
   const padding = (options.fontSize + yAxisDigits) * 3;


### PR DESCRIPTION
# Description of changes

- when the highest Y value is 4 or more digits, it pushes the chart lines down
- add an adjustment to push the lines back up
- tested with 2 - 6 digit max Y values

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [x] No back-end changes
- [x] Manually tested changes
- [x] Added copyrights to new files
- [x] Connected ticket to PR
