### PR TITLE
roadmap #927: fix error display when there's no errors

### DIFF
--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTableLegend.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DonorSummaryTableLegend.tsx
@@ -117,7 +117,7 @@ const DonorSummaryTableLegend = ({
               />
             </TableLegendSection>
           </Col>
-          {FEATURE_PROGRAM_DASHBOARD_RNA_ENABLED && showMissingDNAErrors && (
+          {FEATURE_PROGRAM_DASHBOARD_RNA_ENABLED && !!showMissingDNAErrors && (
             <Col sm={12} md={4} lg={4} xl={4}>
               {!!missingSamplesCount && (
                 <TableLegendSection>

--- a/generated/gql_types.tsx
+++ b/generated/gql_types.tsx
@@ -1279,8 +1279,8 @@ export type TumorNormalMatchedPairStatusCount = {
   __typename?: 'TumorNormalMatchedPairStatusCount';
   noData: Scalars['Int'];
   tumorNormalMatchedPair: Scalars['Int'];
-  tumorNormalNoMatchedPair: Scalars['Int'];
   tumorNormalMatchedPairMissingRawReads: Scalars['Int'];
+  tumorNormalNoMatchedPair: Scalars['Int'];
 };
 
 export type TumorNormalStatusCount = {


### PR DESCRIPTION
# Description of changes

- issue 1: couldn't reproduce. I think it's fixed in another PR
- issue 2: add double exclamation point operator to error display check, because it was showing a 0

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [x] No back-end changes
- [x] Manually tested changes
- [x] Added copyrights to new files
- [x] Connected ticket to PR
