### PR TITLE
#2549 Filter By Submitter Donor id And Donor id for same Donor Gives Confusing Results

### DIFF
--- a/components/pages/submission-system/program-submitted-data/SearchBar/FilterModal/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/SearchBar/FilterModal/index.tsx
@@ -89,11 +89,27 @@ export default function FilterModal({
     },
   );
 
+  //number of instances users entered donor id and submitter id that represent the same entry
+  const numOfDoubleCountedId = () => {
+    const doubleCountedResult = {};
+    searchResultData?.clinicalSearchResults?.searchResults.forEach((ele) => {
+      doubleCountedResult[ele.donorId] = ele.submitterDonorId;
+    });
+    let counter = 0;
+    filterDonorIds.forEach((ele) => {
+      if (filterSubmitterIds.includes(doubleCountedResult[ele])) {
+        counter++;
+      }
+    });
+    return counter;
+  };
+
   useEffect(() => {
     //format the string from text area of the modal to create an set of IDs, so we know the total number
     const filteredTextAreaIDs = new Set();
 
-    const initialIdsCount = filterDonorIds.length + filterSubmitterIds.length;
+    const initialIdsCount =
+      filterDonorIds.length + filterSubmitterIds.length - numOfDoubleCountedId();
 
     // remove the IDs in each result from the set. to then use the set size as the unmatched IDs count
     const queryResults = searchResultData?.clinicalSearchResults?.searchResults || [];

--- a/components/pages/submission-system/program-submitted-data/SearchBar/FilterModal/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/SearchBar/FilterModal/index.tsx
@@ -26,6 +26,7 @@ import UploadButton from './UploadButton';
 import { ClinicalEntitySearchResultResponse, defaultClinicalEntityFilters } from '../../common';
 import CLINICAL_ENTITY_SEARCH_RESULTS_QUERY from '../gql/CLINICAL_ENTITY_SEARCH_RESULTS_QUERY';
 import { useQuery } from '@apollo/client';
+import { filter } from 'lodash';
 
 declare global {
   interface Window {
@@ -68,7 +69,7 @@ export default function FilterModal({
 
   // format text from text area of the filter modal from string to an array of strings
   const filterSubmitterIds = matchSubmitterDonorIds(filterTextBox)
-    .filter((id) => parseInt(id) === NaN || !filterDonorIds.includes(matchDonorIds(id)[0]))
+    .filter((id) => !filterDonorIds.includes(matchDonorIds(id)[0]))
     .filter(Boolean);
 
   // enter the formatted array of string to query and return the matched strings
@@ -88,20 +89,21 @@ export default function FilterModal({
       },
     },
   );
+  // console.log('filterDonorIds', filterDonorIds, 'filterSubmitterIds', filterSubmitterIds);
 
   //number of instances users entered donor id and submitter id that represent the same entry
   const numOfDoubleCountedId = () => {
-    const doubleCountedResult = {};
-    searchResultData?.clinicalSearchResults?.searchResults.forEach((ele) => {
-      doubleCountedResult[ele.donorId] = ele.submitterDonorId;
-    });
-    let counter = 0;
-    filterDonorIds.forEach((ele) => {
-      if (filterSubmitterIds.includes(doubleCountedResult[ele])) {
-        counter++;
-      }
-    });
-    return counter;
+    const doubleCountedResult = searchResultData?.clinicalSearchResults?.searchResults.map(
+      ({ donorId, submitterDonorId }) => ({
+        [donorId]: submitterDonorId,
+      }),
+    ) || [{}];
+
+    const counter = filterDonorIds.filter((donorId) =>
+      filterSubmitterIds.includes(doubleCountedResult[0][donorId]),
+    );
+
+    return counter.length;
   };
 
   useEffect(() => {


### PR DESCRIPTION
# Description of changes

At the bottom of `Filter Modal`, Unmatched IDs count is incorrect due to double counting the same entry when both its donor_id and submitter_id are entered in the text box. A function, `numOfDoubleCountedId()` is created to count the instance and then subtracted from the `initialIdsCount`.

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [x] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [x] No back-end changes
- [x] Manually tested changes
- [ ] Added copyrights to new files
- [x] Connected ticket to PR

The following screenshots are in program, HNAHAL. The inputs are two donor_ids and submitter_id pairs. 

Without removal of double counting, in DEV, instead of Matched IDs = 2, there is also Unmatched IDs = 2. The unmatched IDs are incorrect.
![Screenshot 2023-02-17 at 2 53 39 PM](https://user-images.githubusercontent.com/79996555/219778295-3c0bd1f8-a687-4a6e-93ca-f534b2f251e7.png)

With the new function that removes the double count, the Unmatched IDs is now 0. This screenshot is in localhost, with the changes. 
![Screenshot 2023-02-17 at 2 53 55 PM](https://user-images.githubusercontent.com/79996555/219780317-485ebe83-ef64-46fa-ad17-4a62352b12e2.png)

