### PR TITLE
🧽 Chore: Fix Submitted Data Search Bar Margin

### DIFF
--- a/components/pages/submission-system/program-submitted-data/SearchBar/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/SearchBar/index.tsx
@@ -45,6 +45,7 @@ import {
   searchBoldTextStyle,
   searchClearFilterStyle,
   searchDownArrowStyle,
+  searchDownloadButtonStyle,
   searchDropdownStyle,
   searchFilterButtonStyle,
   searchFilterContainerStyle,
@@ -183,7 +184,7 @@ export default function SearchBar({
       <div css={searchRightSideGroupStyle}>
         {/* Second item - filter */}
         <div css={searchFilterParentStyle}>
-          <Typography variant="subtitle2">Quick Filters:</Typography>
+          <Typography variant="label">Quick Filters:</Typography>
           <DropdownButton
             css={searchDropdownStyle}
             disabled={!!currentDonors.length}
@@ -257,13 +258,15 @@ export default function SearchBar({
         </div>
 
         {/* Fourth item - download button*/}
-        <ClinicalDownloadButton
-          tsvDownloadIds={tsvDownloadIds}
-          text="Clinical Data"
-          entityTypes={clinicalEntityFields}
-          completionState={completionState}
-          disabled={noData}
-        />
+        <div css={searchDownloadButtonStyle}>
+          <ClinicalDownloadButton
+            tsvDownloadIds={tsvDownloadIds}
+            text="Clinical Data"
+            entityTypes={clinicalEntityFields}
+            completionState={completionState}
+            disabled={noData}
+          />
+        </div>
       </div>
     </Container>
   );

--- a/components/pages/submission-system/program-submitted-data/SearchBar/style.tsx
+++ b/components/pages/submission-system/program-submitted-data/SearchBar/style.tsx
@@ -56,7 +56,7 @@ export const searchFilterParentStyle = css`
   display: flex;
   align-items: center;
   width: fit-content;
-  margin: 0 10px;
+  margin: 5px 10px;
 `;
 
 export const searchDropdownStyle = css`
@@ -77,8 +77,14 @@ export const searchBarParentStyle = css`
   border-style: solid;
   border-color: #babcc2;
   border-width: 1px;
-  margin: 0 10px;
+  margin: 5px 10px;
   position: relative;
+`;
+
+export const searchDownloadButtonStyle = css`
+  display: flex;
+  align-items: center;
+  margin: 5px 10px;
 `;
 
 export const searchInputFieldStyle = css`


### PR DESCRIPTION
# Description of changes
Fixes margin between 'Clinical Data' download button on Submitted Data Search Bar on small browser windows

**In Dev/QA:**
<img width="896" alt="Screen Shot 2023-03-20 at 4 26 59 PM" src="https://user-images.githubusercontent.com/15621876/226458585-ce1fc143-e862-4021-9c7f-5f2e953c2b47.png">
See Clinical Data Download Button

**This branch:**
<img width="894" alt="Screen Shot 2023-03-20 at 4 27 08 PM" src="https://user-images.githubusercontent.com/15621876/226458741-4d7f6b3c-ca89-4189-9330-37667db6ca4f.png">



- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [ ] No back-end changes
- [ ] Manually tested changes
- [ ] Added copyrights to new files
- [ ] Connected ticket to PR
