### PR TITLE
remove unmatched id field and update matched id calculation

### DIFF
--- a/components/pages/submission-system/program-submitted-data/SearchBar/FilterModal/MatchResults.tsx
+++ b/components/pages/submission-system/program-submitted-data/SearchBar/FilterModal/MatchResults.tsx
@@ -20,48 +20,23 @@
 import React from 'react';
 import { css } from '@icgc-argo/uikit';
 
-export default function MatchResults({
-  numMatched,
-  numUnmatched,
-}: {
-  numMatched: number;
-  numUnmatched: number;
-}) {
+export default function MatchResults({ numMatched }: { numMatched: number }) {
   return (
-    <>
-      <div
+    <div
+      css={css`
+        display: flex;
+        align-items: center;
+      `}
+    >
+      Matched IDs:
+      <b
         css={css`
-          display: flex;
-          align-items: center;
+          margin-left: 4px;
+          color: #0774d3;
         `}
       >
-        Matched IDs:
-        <b
-          css={css`
-            margin-left: 4px;
-            color: #0774d3;
-          `}
-        >
-          {numMatched}
-        </b>
-      </div>
-      {/* <div> of unmatched ID */}
-      <div
-        css={css`
-          display: flex;
-          align-items: center;
-        `}
-      >
-        Unmatched IDs:
-        <b
-          css={css`
-            margin-left: 4px;
-            color: #0774d3;
-          `}
-        >
-          {numUnmatched}
-        </b>
-      </div>
-    </>
+        {numMatched}
+      </b>
+    </div>
   );
 }

--- a/components/pages/submission-system/program-submitted-data/SearchBar/FilterModal/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/SearchBar/FilterModal/index.tsx
@@ -61,7 +61,6 @@ export default function FilterModal({
 
   //make matchID dynamic using useState
   const [numMatched, setNumMatched] = useState(0);
-  const [numUnmatched, setNumUnmatched] = useState(0);
   const [matchedIds, setMatchedIds] = useState('');
 
   // Match text area contents for Donor ID #s
@@ -89,48 +88,31 @@ export default function FilterModal({
       },
     },
   );
-  // console.log('filterDonorIds', filterDonorIds, 'filterSubmitterIds', filterSubmitterIds);
-
-  //number of instances users entered donor id and submitter id that represent the same entry
-  const numOfDoubleCountedId = () => {
-    const doubleCountedResult = searchResultData?.clinicalSearchResults?.searchResults.map(
-      ({ donorId, submitterDonorId }) => ({
-        [donorId]: submitterDonorId,
-      }),
-    ) || [{}];
-
-    const counter = filterDonorIds.filter((donorId) =>
-      filterSubmitterIds.includes(doubleCountedResult[0][donorId]),
-    );
-
-    return counter.length;
-  };
 
   useEffect(() => {
-    //format the string from text area of the modal to create an set of IDs, so we know the total number
+    // This set contain unique ids inputs (no duplicates)
     const filteredTextAreaIDs = new Set();
 
-    const initialIdsCount =
-      filterDonorIds.length + filterSubmitterIds.length - numOfDoubleCountedId();
-
-    // remove the IDs in each result from the set. to then use the set size as the unmatched IDs count
+    // Queried results of ids on current submitted data page
     const queryResults = searchResultData?.clinicalSearchResults?.searchResults || [];
 
+    // Adding matching ids of queried and text field results to the Set
     queryResults.forEach((result) => {
       const donorIdMatch = filterDonorIds.includes(result.donorId);
       const submitterIdMatch = filterSubmitterIds.includes(result.submitterDonorId);
 
-      if (donorIdMatch || submitterIdMatch) {
+      if (donorIdMatch) {
         filteredTextAreaIDs.add(result.donorId);
+      }
+      if (submitterIdMatch) {
+        filteredTextAreaIDs.add(result.submitterDonorId);
       }
     });
 
-    // Update MatchResults Component with the matched and unmatched number
+    // Update MatchResults Component with the matched number
     const matchedCount = filteredTextAreaIDs.size;
-    const unmatchedCount = initialIdsCount - filteredTextAreaIDs.size;
 
     setNumMatched(matchedCount);
-    setNumUnmatched(unmatchedCount);
     setMatchedIds(Array.from(filteredTextAreaIDs).join(','));
   }, [searchResultData]);
 
@@ -195,7 +177,7 @@ export default function FilterModal({
               Your ID List results in:
             </b>
             {/* section of matched and unmatched ID */}
-            <MatchResults numMatched={numMatched} numUnmatched={numUnmatched} />
+            <MatchResults numMatched={numMatched} />
             {/* <Button> of clear button */}
             {filterTextBox && (
               <Button
@@ -203,6 +185,7 @@ export default function FilterModal({
                   setFilterTextBox('');
                 }}
                 css={css`
+                  margin-top: 0px;
                   border: none;
                   width: fit-content;
                   padding: 2px;


### PR DESCRIPTION
The unmatched id field has a vague definition and unknown usefulness to the users, so it's removed.

The matched id field now returns all the id that is matched. There are two cases to think about:

1. When the exact same id is enter more than once -> it will be count as 1. 
    This is same as before as we don't want to double count duplicates.
2. When the donor and submitter id from the same entry is entered -> it will be count as 2.
     BA in the ticket stated the goal is to allow the users to know the total number of matches.
3. When the donor and submitted id from the same entry is entered more than once -> due to 1. this will still be counted as 2 
     because 1. eliminates duplicates. 

## Type of Change

- [ ] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [ ] No back-end changes
- [ ] Manually tested changes
- [ ] Added copyrights to new files
- [ ] Connected ticket to PR
