### PR TITLE
🐛 Revise Normal/Tumour Stats after updating Specimen Stats on Clinical

### DIFF
--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -456,12 +456,12 @@ const ClinicalEntityDataTable = ({
                     clinicalRecord[completionField] =
                       normalSpecimensPercentage === 1 || normalSpecimensPercentage === 0
                         ? normalSpecimensPercentage
-                        : -normalRegistrations;
+                        : normalRegistrations;
                   } else if (completionField === completionColumnHeaders['tumourSpecimens']) {
                     clinicalRecord[completionField] =
                       tumourSpecimensPercentage === 1 || tumourSpecimensPercentage === 0
                         ? tumourSpecimensPercentage
-                        : -tumourRegistrations;
+                        : tumourRegistrations;
                   }
                 }
               });
@@ -535,7 +535,7 @@ const ClinicalEntityDataTable = ({
     const errorState =
       // Completion Stats === 1 indicates Complete
       // 0 is Incomplete, <1 Incorrect Sample / Specimen Ratio
-      (isCompletionCell && original[id] < 1) ||
+      (isCompletionCell && original[id] !== 1) ||
       specificErrorValue?.length > 0 ||
       fieldError?.length > 0;
 
@@ -641,22 +641,12 @@ const ClinicalEntityDataTable = ({
           ...column,
           maxWidth: noTableData ? 50 : 250,
           style: noTableData ? noDataCellStyle : {},
-          Cell: ({ value }) => {
-            // Specimen Normal / Tumour stats are sent as negative numbers to indicate errors
-            const hasSpecimenError =
-              (column.id === completionColumnHeaders['normalSpecimens'] ||
-                column.id === completionColumnHeaders['tumourSpecimens']) &&
-              value < 1;
-
-            return value === 1 ? (
+          Cell: ({ value }) =>
+            value === 1 ? (
               <Icon name="checkmark" fill="accent1_dimmed" width="12px" height="12px" />
-            ) : hasSpecimenError ? (
-              // This removes the negative symbol for NS/TS error display
-              -value
             ) : (
               value
-            );
-          },
+            ),
         })),
       },
       {

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -452,16 +452,14 @@ const ClinicalEntityDataTable = ({
 
                   if (coreCompletionPercentage === 1) {
                     clinicalRecord[completionField] = 1;
-                  } else if (coreCompletionPercentage === 0) {
-                    clinicalRecord[completionField] = 0;
                   } else if (completionField === completionColumnHeaders['normalSpecimens']) {
                     clinicalRecord[completionField] =
-                      normalSpecimensPercentage === 1
+                      normalSpecimensPercentage === 1 || normalSpecimensPercentage === 0
                         ? normalSpecimensPercentage
                         : -normalRegistrations;
                   } else if (completionField === completionColumnHeaders['tumourSpecimens']) {
                     clinicalRecord[completionField] =
-                      tumourSpecimensPercentage === 1
+                      tumourSpecimensPercentage === 1 || tumourSpecimensPercentage === 0
                         ? tumourSpecimensPercentage
                         : -tumourRegistrations;
                   }

--- a/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
+++ b/components/pages/submission-system/program-submitted-data/ClinicalEntityDataTable/index.tsx
@@ -452,6 +452,8 @@ const ClinicalEntityDataTable = ({
 
                   if (coreCompletionPercentage === 1) {
                     clinicalRecord[completionField] = 1;
+                  } else if (coreCompletionPercentage === 0) {
+                    clinicalRecord[completionField] = 0;
                   } else if (completionField === completionColumnHeaders['normalSpecimens']) {
                     clinicalRecord[completionField] =
                       normalSpecimensPercentage === 1


### PR DESCRIPTION
# Description of changes

UI was incorrectly rendering all Normal/Tumour Specimen stats
Should only render stats for records with submitted Clinical Info

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [ ] No back-end changes
- [ ] Manually tested changes
- [ ] Added copyrights to new files
- [ ] Connected ticket to PR
