### PR TITLE
Update proxy paths to match API update

### DIFF
--- a/components/pages/submission-system/program-dashboard/DonorDataSummary/DownloadButtons.tsx
+++ b/components/pages/submission-system/program-dashboard/DonorDataSummary/DownloadButtons.tsx
@@ -88,7 +88,9 @@ const DownloadButtons = () => {
 
     const url = urlJoin(
       GATEWAY_API_ROOT,
-      `/clinical/program/${programShortName}/all-clinical-data`,
+      `/clinical/proxy/program`,
+      programShortName,
+      `all-clinical-data`,
     );
 
     setButtonLoadingState(true);

--- a/components/pages/submission-system/program-submitted-data/DownloadButtons.tsx
+++ b/components/pages/submission-system/program-submitted-data/DownloadButtons.tsx
@@ -103,7 +103,7 @@ const ClinicalDownloadButton = ({
 
     const url = urlJoin(
       GATEWAY_API_ROOT,
-      `/clinical/program/`,
+      `/clinical/proxy/program/`,
       programShortName,
       `/clinical-data-tsv`,
     );


### PR DESCRIPTION
# Description of changes

Update URL path for all calls to clinical proxies. The path is being updated form `/clinical/programs` to `/clinical/proxy/programs` in the platform-api: https://github.com/icgc-argo/platform-api/pull/673

Two buttons interact with download requests through this proxy, both have been updated.

## Type of Change

- [ ] Bug
- [ ] Dependency updates
- [x] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)
