### PR TITLE
bug/#2681-program-entity-summary-section-with-multiple-values-missing-delimiter(comma)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx --no pretty-quick@^2.0.1 --staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no pretty-quick@^2.0.1 --staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run graphql-codegen
-npm run type-check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run graphql-codegen
+npm run type-check

--- a/components/pages/program-entity/ProgramCardsLayout/util.tsx
+++ b/components/pages/program-entity/ProgramCardsLayout/util.tsx
@@ -21,7 +21,6 @@ import sqonBuilder from 'sqon-builder';
 import type { ProgramSummaryQuery } from '../types';
 
 export const createProgramSummaryData = (programSummaryQuery: ProgramSummaryQuery) => {
-  console.log('programSummaryQuery!!!!', programSummaryQuery);
   return {
     'Program Shortname': programSummaryQuery?.shortName || '',
     'Full Program Name': programSummaryQuery?.name || '',

--- a/components/pages/program-entity/ProgramCardsLayout/util.tsx
+++ b/components/pages/program-entity/ProgramCardsLayout/util.tsx
@@ -21,12 +21,13 @@ import sqonBuilder from 'sqon-builder';
 import type { ProgramSummaryQuery } from '../types';
 
 export const createProgramSummaryData = (programSummaryQuery: ProgramSummaryQuery) => {
+  console.log('programSummaryQuery!!!!', programSummaryQuery);
   return {
     'Program Shortname': programSummaryQuery?.shortName || '',
     'Full Program Name': programSummaryQuery?.name || '',
     Description: programSummaryQuery?.description || '',
-    Countries: programSummaryQuery?.countries || '',
-    'Primary Sites': programSummaryQuery?.primarySites || '',
+    Countries: programSummaryQuery?.countries?.join(', ') || '',
+    'Primary Sites': programSummaryQuery?.primarySites?.join(', ') || '',
     Website: programSummaryQuery.website ? (
       <Link
         href={programSummaryQuery.website}
@@ -35,9 +36,9 @@ export const createProgramSummaryData = (programSummaryQuery: ProgramSummaryQuer
     ) : (
       ''
     ),
-    Institutions: programSummaryQuery?.institutions || '',
-    'Processing Regions': programSummaryQuery?.regions || '',
-    'Cancer Types': programSummaryQuery?.cancerTypes || '',
+    Institutions: programSummaryQuery?.institutions?.join(', ') || '',
+    'Processing Regions': programSummaryQuery?.regions?.join(', ') || '',
+    'Cancer Types': programSummaryQuery?.cancerTypes?.join(', ') || '',
   };
 };
 


### PR DESCRIPTION
**Issue:** Program Entity table rows with multiple values are missing spaces and comma between these values. These rows are regions, countries, institutions, primarySites and cancerTypes

**Solution:** format the query with array.join() method. The results are values with space and commas in between.

Was able to test countries, primarySites in dev. Couldn't edit programs to test the other three rows. But since the update works on countries and primarySites, it should work for the rest as well.

**Screenshot**
Showing space and comma between values in primarySites and countries.
![Screenshot 2023-11-30 at 4 20 09 PM](https://github.com/icgc-argo/platform-ui/assets/79996555/cd7b4f97-6151-43cd-8335-b4c8512b957a)

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [x] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [ ] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [ ] No back-end changes
- [x] Manually tested changes
- [ ] Added copyrights to new files
- [x] Connected ticket to PR
