### PR TITLE
Select all on file repo does not select files for clinical download

### DIFF
--- a/components/pages/file-repository/FileTable/index.tsx
+++ b/components/pages/file-repository/FileTable/index.tsx
@@ -346,11 +346,6 @@ const FileTable = () => {
     selectionKeyField: 'objectId',
   });
 
-  // When allRowsSelected is true, selectedRows is empty, so objectIds need to be populated
-  const selectedFilesObjectIds = allRowsSelected
-    ? fileRepoEntries.map((record) => record['objectId'])
-    : selectedRows;
-
   const tableElement = (
     <div
       ref={containerRef}
@@ -426,7 +421,7 @@ const FileTable = () => {
           >
             <TsvDownloadButton
               allFilesSelected={allRowsSelected}
-              selectedFilesObjectIds={selectedFilesObjectIds}
+              selectedFilesObjectIds={selectedRows}
               unSelectedFilesObjectIds={unselectedRows}
               selectedFilesCount={selectedRowsCount}
             />


### PR DESCRIPTION
This change restores the original behaviour for the select all button on the file repo, which is that the allRowsSelected variable is true but we don't list any selected rows. The implementation being removed here is incorrectly setting the selected rows to include only the current page of results, despite the "select all" graphics indicating the entire set is selected.

A long term solution to downloading a larger clinical data set is still required, this is simply removing a UI change that would possibly introduce confusing behaviour.

## Type of Change

- [x] Bug
- [ ] Dependency updates
- [ ] Feature
- [ ] Refactoring
- [ ] Release candidate
- [ ] Styling
- [ ] Testing
- [ ] Other (please describe)

## Checklist before requesting review

- Design (select one):
  - [ ] Matches design:
    - component sizes, spacing, and styles
    - font size, weight, colour
    - spelling has been double checked
  - [x] No design provided, screenshot of changes included in PR
  - [ ] No changes to UI
- Back-end (select one):
  - [ ] Back-end PRs merged, tested on develop, and linked in this PR
  - [x] No back-end changes
- [x] Manually tested changes
- [x] Added copyrights to new files
- [ ] Connected ticket to PR
