### PR TITLE
disabled clinical download button when all files are selected

### DIFF
--- a/components/pages/file-repository/FileTable/TsvDownloadButton.tsx
+++ b/components/pages/file-repository/FileTable/TsvDownloadButton.tsx
@@ -73,7 +73,10 @@ const TsvDownloadButton = ({
   // - user is logged in and has DACO access
   // - files are selected (TODO: download all by filter)
   const showClinicalDownload =
-    FEATURE_CLINICAL_DOWNLOAD && hasDacoAccess(permissions) && selectedFilesCount > 0;
+    FEATURE_CLINICAL_DOWNLOAD &&
+    hasDacoAccess(permissions) &&
+    selectedFilesCount > 0 &&
+    !allFilesSelected;
 
   const menuItems: DownloadButtonProps<DownloadOptionValues>['menuItems'] = [
     ...(!!selectedFilesCount


### PR DESCRIPTION
# Description of changes

reference ticket url: https://github.com/icgc-argo/roadmap/issues/1056#event-15640319491

In this PR, I've addressed an issue with the clinical download functionality when using the "Select All" feature in the table and requesting clinical download files. Previously, the clinical download button remained active even when all rows were selected. This would lead to an non descriptive error response from the server due to processing files.  

Now, the button is automatically disabled whenever the "Select All" function is triggered. This change addresses part one of the ticket work "Quick/Temporary Solution". Implementing code to identify when "Select All" is selected and disabling "Clinical Data" download from the dropdown by conditionally rendering it. As we do not even render the button, there is no risk to inspecting the element and clicking on it via the DOM. 
